### PR TITLE
Improve global command and keyboard

### DIFF
--- a/sample_global.json
+++ b/sample_global.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "active_cryptocurrencies": 10000,
+    "markets": 600,
+    "total_market_cap": {"usd": 2000000000000},
+    "total_volume": {"usd": 80000000000},
+    "market_cap_change_percentage_24h_usd": 0.25,
+    "market_cap_percentage": {"btc": 40.1, "eth": 18.2}
+  }
+}


### PR DESCRIPTION
## Summary
- offer top 3 coins in the Subscribe keyboard
- add fallback data for /global
- show more details from the global market API

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687553210f64832193ed767cdff09e13