### PR TITLE
Use DB_PATH from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 TELEGRAM_TOKEN=
+# Path to the SQLite database file (defaults to subs.db)
 DB_PATH=./crypto.db

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env             # edit TELEGRAM_TOKEN
+# DB_PATH sets the SQLite file used (default subs.db)
 cp config.json.example config.json
 python run.py
 ```

--- a/run.py
+++ b/run.py
@@ -36,7 +36,8 @@ from telegram.ext import (
 
 matplotlib.use("Agg")
 
-DB_FILE = "subs.db"
+load_dotenv()
+DB_FILE = os.getenv("DB_PATH", "subs.db")
 BOT_NAME = "PricePulseWatcherBot"
 DEFAULT_THRESHOLD = 0.1
 DEFAULT_INTERVAL = 60


### PR DESCRIPTION
## Summary
- read DB_PATH from the environment when starting the bot
- document DB_PATH in README and .env example

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755a85494c83218103168824929670