### PR TITLE
Fix unsubscribe command response duplication

### DIFF
--- a/run.py
+++ b/run.py
@@ -654,9 +654,6 @@ async def unsubscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     logger.info(
         "chat %s unsubscribes via command from %s", update.effective_chat.id, coin
     )
-    await update.message.reply_text(
-        f"{SUCCESS_EMOJI} Unsubscribed from {symbol_for(coin)} alerts"
-    )
 
     await update.message.reply_text(
         f"{SUCCESS_EMOJI} Unsubscribed from {symbol_for(coin)} alerts",


### PR DESCRIPTION
## Summary
- remove duplicated reply in `unsubscribe_cmd`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755a9470748321bac931a70c664cd1