### PR TITLE
Add shebang to run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import asyncio
 import json
 import logging


### PR DESCRIPTION
## Summary
- allow running run.py as a script by adding a shebang line

## Testing
- `isort run.py`
- `black run.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755aeb911c8321a644a4226f7515d6