### PR TITLE
Implement /trends command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ price check frequency. Start the bot and run `/start` in a chat with it.
 - `/list` – list active subscriptions
 - `/info <coin>` – show current coin data
 - `/chart <coin> [days]` – plot price history (alias `/charts`)
+- `/trends` – show trending coins
 - `/global` – show global market stats
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.


### PR DESCRIPTION
## Summary
- add a `/trends` command to display trending coins
- document the new command in help text and README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e5055fe0832186f1546934ce3d68