### PR TITLE
Handle tiny coins for milestone alerts

### DIFF
--- a/run.py
+++ b/run.py
@@ -242,7 +242,13 @@ def milestone_step(price: float) -> float:
         return 0.1
     if price >= 0.1:
         return 0.01
-    return 0.001
+    if price >= 0.01:
+        return 0.001
+    if price >= 0.001:
+        return 0.0001
+    if price >= 0.0001:
+        return 0.00001
+    return 0.000001
 
 
 def format_price(value: float) -> str:

--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -13,6 +13,9 @@ def test_milestone_step():
     assert milestone_step(5) == 0.1
     assert milestone_step(0.5) == 0.01
     assert milestone_step(0.05) == 0.001
+    assert milestone_step(0.005) == 0.0001
+    assert milestone_step(0.0005) == 0.00001
+    assert milestone_step(0.00005) == 0.000001
 
 
 def test_milestones_crossed_up():


### PR DESCRIPTION
## Summary
- support prices down to `1e-6` in `milestone_step`
- test new milestone thresholds for tiny coins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687660e8695c8321bfe4618ff17742b5