### PR TITLE
Enable file logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ COINGECKO_API_KEY=
 PRICE_API_PROVIDER=coingecko
 # Optional CoinMarketCap API key
 COINMARKETCAP_API_KEY=
+# Log verbosity level (INFO, DEBUG, etc.)
+LOG_LEVEL=INFO
+# File path for log output (default bot.log)
+LOG_FILE=bot.log

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ pip install -r requirements.txt
 cp .env.example .env             # edit TELEGRAM_TOKEN
 # DB_PATH sets the SQLite file used (default subs.db)
 # COINGECKO_API_KEY is optional for higher rate limits
+# LOG_LEVEL enables verbose output when set to DEBUG
+# LOG_FILE writes logs to the given file (default bot.log)
 cp config.json.example config.json
 python run.py
 ```

--- a/run.py
+++ b/run.py
@@ -182,7 +182,16 @@ async def fetch_top_coins() -> None:
         logger.error("error fetching top coins: %s", exc)
 
 
-logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO").upper())
+LOG_FILE = os.getenv("LOG_FILE")
+_handlers = [logging.StreamHandler()]
+if LOG_FILE:
+    _handlers.append(logging.FileHandler(LOG_FILE))
+
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO").upper(),
+    handlers=_handlers,
+    force=True,
+)
 logger = logging.getLogger(__name__)
 
 # price cache: coin -> (price, timestamp)


### PR DESCRIPTION
## Summary
- allow logging to a file and force configuration
- document LOG_LEVEL and LOG_FILE env vars in README and `.env.example`

## Testing
- `isort --check-only run.py`
- `black --check run.py`
- `flake8`
- `pytest -q`
- `shellcheck install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68765f4b4324832195d60a319536c70c