### PR TITLE
Add coin validation for /add command

### DIFF
--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import run  # noqa: E402
+
+
+def test_suggest_coins_basic():
+    run.COINS[:] = ["bitcoin", "ethereum", "dogecoin"]
+    run.TOP_COINS[:] = []
+    suggestions = run.suggest_coins("bitcin")
+    assert suggestions[0] == "bitcoin"


### PR DESCRIPTION
## Summary
- suggest coins when /add receives an unknown name
- validate a coin exists before subscribing
- test coin suggestion helper

## Testing
- `isort . && black . && flake8 && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68766833b540832191c2152795f83f90