### PR TITLE
Implement reload keyboard refresh

### DIFF
--- a/run.py
+++ b/run.py
@@ -1069,8 +1069,8 @@ ERROR_EMOJI = "\u26a0\ufe0f"
 
 
 def get_keyboard() -> ReplyKeyboardMarkup:
-    # Offer quick-add buttons for random popular coins
-    coins_source = TOP_COINS[:20] if TOP_COINS else (COINS or ["bitcoin"])
+    # Offer quick-add buttons from trending coins when available
+    coins_source = COINS or TOP_COINS[:20] or ["bitcoin"]
     coins = random.sample(coins_source, k=min(3, len(coins_source)))
     subs = [KeyboardButton(f"{SUB_EMOJI} Add {symbol_for(c)}") for c in coins]
     keyboard = [
@@ -1519,7 +1519,17 @@ async def menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             chat_id=update.effective_chat.id,
             message_id=update.message.message_id,
         )
-        # Do not send any text after reloading the keyboard
+        # Send a short message with a new keyboard then delete it so the
+        # persistent keyboard gets updated without cluttering the chat
+        msg = await context.bot.send_message(
+            chat_id=update.effective_chat.id,
+            text="\u200b",
+            reply_markup=get_keyboard(),
+        )
+        await context.bot.delete_message(
+            chat_id=update.effective_chat.id,
+            message_id=msg.message_id,
+        )
     elif text == f"{LIST_EMOJI} List":
         await list_cmd(update, context)
     elif text == f"{HELP_EMOJI} Help":


### PR DESCRIPTION
## Summary
- rotate suggested coins on reload using trending list
- suppress reload text output by using zero-width placeholder

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877655da3448321abc8a3f4bcdbf297