### PR TITLE
Switch to dotenv config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ COINGECKO_BASE_URL=
 LOG_LEVEL=INFO
 # File path for log output (default bot.log)
 LOG_FILE=bot.log
+# Default percent change that triggers an alert
+DEFAULT_THRESHOLD=0.1
+# Default subscription interval
+DEFAULT_INTERVAL=5m
+# How often prices are checked
+PRICE_CHECK_INTERVAL=30s

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # COINGECKO_BASE_URL sets the CoinGecko endpoint (use the pro URL if you have a paid plan)
 # LOG_LEVEL enables verbose output when set to DEBUG
 # LOG_FILE writes logs to the given file (default bot.log)
-cp config.json.example config.json
+# DEFAULT_THRESHOLD sets the default percent change for alerts
+# DEFAULT_INTERVAL sets the default subscription interval
+# PRICE_CHECK_INTERVAL controls how often prices are checked
 python run.py
 ```
 
-Adjust `config.json` to change the default threshold, subscription interval or
-price check frequency. Start the bot and run `/start` in a chat with it.
+Edit `.env` to change the default threshold, subscription interval or price
+check frequency. Start the bot and run `/start` in a chat with it.
 
 ## Configuration
 
-Create `.env` and `config.json` files from the provided examples. The env file holds credentials and runtime options:
+Create `.env` from the provided example. This file holds credentials and runtime options:
 
 - `TELEGRAM_TOKEN` – token from BotFather
 - `DB_PATH` – SQLite database path (default `subs.db`)
@@ -41,12 +43,9 @@ Create `.env` and `config.json` files from the provided examples. The env file h
 - `COINGECKO_BASE_URL` – override to use the pro CoinGecko endpoint
 - `LOG_LEVEL` – log level such as INFO
 - `LOG_FILE` – file to write logs to
-
-`config.json` contains defaults controlling alert behaviour:
-
-- `default_threshold` – percent change that triggers an alert
-- `default_interval` – subscription interval when none is given
-- `price_check_interval` – how often prices are checked
+- `DEFAULT_THRESHOLD` – percent change that triggers an alert
+- `DEFAULT_INTERVAL` – subscription interval when none is given
+- `PRICE_CHECK_INTERVAL` – how often prices are checked
 
 ### Commands
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,0 @@
-{
-  "default_threshold": 0.1,
-  "default_interval": "5m",
-  "price_check_interval": "30s"
-}

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -1,0 +1,32 @@
+import os
+import re
+
+from dotenv import load_dotenv
+
+
+def parse_duration(value: str) -> int:
+    """Return seconds for a duration string like '15m' or '1h'."""
+    if value.isdigit():
+        return int(value)
+    match = re.fullmatch(r"(\d+)([dhms])", value.lower())
+    if not match:
+        raise ValueError("invalid interval format")
+    num, unit = match.groups()
+    factor = {"d": 86400, "h": 3600, "m": 60, "s": 1}[unit]
+    return int(num) * factor
+
+
+load_dotenv()
+
+BOT_NAME = "PricePulseWatcherBot"
+DB_FILE = os.getenv("DB_PATH", "subs.db")
+DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
+DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
+PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60"))
+COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
+COINGECKO_BASE_URL = os.getenv("COINGECKO_BASE_URL", "https://api.coingecko.com/api/v3")
+COINGECKO_HEADERS = (
+    {"x-cg-pro-api-key": COINGECKO_API_KEY} if COINGECKO_API_KEY else None
+)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+LOG_FILE = os.getenv("LOG_FILE", "bot.log")


### PR DESCRIPTION
## Summary
- add `pricepulsebot` package with config helper
- rely on `.env` for defaults and remove obsolete config.json
- document new environment variables in README and `.env.example`
- update bot code to use config module

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f7d22fbc832190d58a5107504f81