### PR TITLE
Switch to env vars for defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ COINGECKO_BASE_URL=
 LOG_LEVEL=INFO
 # File path for log output (default bot.log)
 LOG_FILE=bot.log
+# Default percent change that triggers an alert
+DEFAULT_THRESHOLD=0.1
+# Default subscription interval when none is specified
+DEFAULT_INTERVAL=5m
+# How often prices are checked
+PRICE_CHECK_INTERVAL=30s

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 __pycache__/
 *.db
 .env
+pricepulsebot.egg-info/

--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # COINGECKO_BASE_URL sets the CoinGecko endpoint (use the pro URL if you have a paid plan)
 # LOG_LEVEL enables verbose output when set to DEBUG
 # LOG_FILE writes logs to the given file (default bot.log)
-cp config.json.example config.json
+# DEFAULT_THRESHOLD and DEFAULT_INTERVAL control new subscriptions
+# PRICE_CHECK_INTERVAL sets how often prices are fetched
 python run.py
 ```
 
-Adjust `config.json` to change the default threshold, subscription interval or
-price check frequency. Start the bot and run `/start` in a chat with it.
+Edit `.env` to change the default threshold, subscription interval or price
+check frequency. Start the bot and run `/start` in a chat with it.
 
 ## Configuration
 
-Create `.env` and `config.json` files from the provided examples. The env file holds credentials and runtime options:
+Create a `.env` file from the example. It holds credentials and runtime options:
 
 - `TELEGRAM_TOKEN` – token from BotFather
 - `DB_PATH` – SQLite database path (default `subs.db`)
@@ -42,11 +43,9 @@ Create `.env` and `config.json` files from the provided examples. The env file h
 - `LOG_LEVEL` – log level such as INFO
 - `LOG_FILE` – file to write logs to
 
-`config.json` contains defaults controlling alert behaviour:
-
-- `default_threshold` – percent change that triggers an alert
-- `default_interval` – subscription interval when none is given
-- `price_check_interval` – how often prices are checked
+- `DEFAULT_THRESHOLD` – percent change that triggers an alert
+- `DEFAULT_INTERVAL` – subscription interval when none is given
+- `PRICE_CHECK_INTERVAL` – how often prices are checked
 
 ### Commands
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,0 @@
-{
-  "default_threshold": 0.1,
-  "default_interval": "5m",
-  "price_check_interval": "30s"
-}

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -7,11 +6,35 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def parse_duration(value: str) -> int:
+    """Return seconds for a duration string like '15m' or '1h'."""
+    if value.isdigit():
+        return int(value)
+    match = re.fullmatch(r"(\d+)([dhms])", value.lower())
+    if not match:
+        raise ValueError("invalid interval format")
+    num, unit = match.groups()
+    factor = {"d": 86400, "h": 3600, "m": 60, "s": 1}[unit]
+    return int(num) * factor
+
+
+def format_interval(seconds: int) -> str:
+    """Return a short string representation for a duration in seconds."""
+    if seconds % 86400 == 0:
+        return f"{seconds // 86400}d"
+    if seconds % 3600 == 0:
+        return f"{seconds // 3600}h"
+    if seconds % 60 == 0:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"
+
+
 DB_FILE = os.getenv("DB_PATH", "subs.db")
 BOT_NAME = "PricePulseWatcherBot"
-DEFAULT_THRESHOLD = 0.1
-DEFAULT_INTERVAL = 300
-PRICE_CHECK_INTERVAL = 60
+DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
+DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
+PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
 COINGECKO_BASE_URL = os.getenv("COINGECKO_BASE_URL", "https://api.coingecko.com/api/v3")
@@ -40,55 +63,3 @@ logging.basicConfig(
     force=True,
 )
 logger = logging.getLogger(__name__)
-
-
-def parse_duration(value: str) -> int:
-    """Return seconds for a duration string like '15m' or '1h'."""
-    if value.isdigit():
-        return int(value)
-    match = re.fullmatch(r"(\d+)([dhms])", value.lower())
-    if not match:
-        raise ValueError("invalid interval format")
-    num, unit = match.groups()
-    factor = {"d": 86400, "h": 3600, "m": 60, "s": 1}[unit]
-    return int(num) * factor
-
-
-def format_interval(seconds: int) -> str:
-    """Return a short string representation for a duration in seconds."""
-    if seconds % 86400 == 0:
-        return f"{seconds // 86400}d"
-    if seconds % 3600 == 0:
-        return f"{seconds // 3600}h"
-    if seconds % 60 == 0:
-        return f"{seconds // 60}m"
-    return f"{seconds}s"
-
-
-def load_config(path: str = "config.json") -> None:
-    """Load defaults from a JSON config if present."""
-    if not os.path.isfile(path):
-        return
-    try:
-        with open(path) as fh:
-            data = json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("failed to load config: %s", exc)
-        return
-
-    global DEFAULT_THRESHOLD, DEFAULT_INTERVAL, PRICE_CHECK_INTERVAL
-    if "default_threshold" in data:
-        try:
-            DEFAULT_THRESHOLD = float(data["default_threshold"])
-        except (TypeError, ValueError):
-            logger.warning("invalid default_threshold in config")
-    if "default_interval" in data:
-        try:
-            DEFAULT_INTERVAL = parse_duration(str(data["default_interval"]))
-        except ValueError:
-            logger.warning("invalid default_interval in config")
-    if "price_check_interval" in data:
-        try:
-            PRICE_CHECK_INTERVAL = parse_duration(str(data["price_check_interval"]))
-        except ValueError:
-            logger.warning("invalid price_check_interval in config")

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -16,7 +16,6 @@ from . import api, config, db, handlers
 
 
 async def main() -> None:
-    config.load_config()
     await db.init_db()
     await api.fetch_trending_coins()
     await api.fetch_top_coins()


### PR DESCRIPTION
## Summary
- extend `.env.example` with new defaults
- drop `config.json` example file
- look up defaults from environment in `config`
- rely on env-based config in the README
- remove call to deprecated `load_config`
- ignore egg-info files

## Testing
- `isort . && black .`
- `flake8`
- `shellcheck install.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687800b67abc8321b057933dfdd0b33b