### PR TITLE
Improve find_coin search match

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -319,14 +319,16 @@ async def find_coin(query: str) -> Optional[str]:
             for item in data.get("coins", []):
                 symbol = item.get("symbol")
                 coin_id = item.get("id")
+                name = item.get("name", "")
+                if coin_id and coin_id.lower() == query.lower():
+                    if symbol:
+                        config.COIN_SYMBOLS[coin_id] = symbol.upper()
+                        config.SYMBOL_TO_COIN[symbol.lower()] = coin_id
+                    return coin_id
                 if symbol and coin_id and symbol.lower() == query.lower():
                     config.COIN_SYMBOLS[coin_id] = symbol.upper()
                     config.SYMBOL_TO_COIN[symbol.lower()] = coin_id
                     return coin_id
-            for item in data.get("coins", []):
-                symbol = item.get("symbol")
-                coin_id = item.get("id")
-                name = item.get("name", "")
                 if coin_id and name.lower() == query.lower():
                     if symbol:
                         config.COIN_SYMBOLS[coin_id] = symbol.upper()

--- a/tests/test_find_coin.py
+++ b/tests/test_find_coin.py
@@ -38,3 +38,24 @@ async def test_find_coin_encodes_query():
         )
         result = await find_coin("bitcoin cash")
         assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_coin_matches_id():
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/search",
+            "GET",
+            Response(
+                text=(
+                    '{"coins": [{"id": "bitcoin", "symbol": "btc", '
+                    '"name": "Bitcoin"}]}'
+                ),
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        result = await find_coin("bitcoin")
+        assert result == "bitcoin"
+        assert api.config.SYMBOL_TO_COIN["btc"] == "bitcoin"


### PR DESCRIPTION
## Summary
- check coin id when scanning search results
- cover coin id match in tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780ab1475883218a89cfccb40b33ba