### PR TITLE
Improve coin suggestion fallback

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -26,11 +26,15 @@ def encoded(coin: str) -> str:
     return quote(coin, safe="-")
 
 
-def suggest_coins(name: str, limit: int = 3) -> list[str]:
+async def suggest_coins(name: str, limit: int = 3) -> list[str]:
     candidates = list({*config.COINS, *config.TOP_COINS, *config.COIN_SYMBOLS.keys()})
     matches = get_close_matches(
         name.lower(), [c.lower() for c in candidates], n=limit, cutoff=0.6
     )
+    if not matches:
+        found = await find_coin(name)
+        return [found] if found else []
+
     coins = [normalize_coin(m) for m in matches]
     seen: set[str] = set()
     result: list[str] = []

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -286,7 +286,7 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
-        suggestions = api.suggest_coins(coin_input)
+        suggestions = await api.suggest_coins(coin_input)
         msg = f"{ERROR_EMOJI} Unknown coin"
         if suggestions:
             syms = ", ".join(api.symbol_for(c) for c in suggestions)
@@ -386,7 +386,7 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
-        suggestions = api.suggest_coins(coin_input)
+        suggestions = await api.suggest_coins(coin_input)
         msg = f"{ERROR_EMOJI} Unknown coin"
         if suggestions:
             syms = ", ".join(api.symbol_for(c) for c in suggestions)
@@ -424,7 +424,7 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     coin_input = context.args[0]
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
-        suggestions = api.suggest_coins(coin_input)
+        suggestions = await api.suggest_coins(coin_input)
         msg = f"{ERROR_EMOJI} Unknown coin"
         if suggestions:
             syms = ", ".join(api.symbol_for(c) for c in suggestions)

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1,8 +1,31 @@
+import pytest
+from aresponses import Response, ResponsesMockServer  # noqa: E402
+
 import pricepulsebot.api as api  # noqa: E402
 
 
-def test_suggest_coins_basic():
+@pytest.mark.asyncio
+async def test_suggest_coins_basic():
     api.config.COINS[:] = ["bitcoin", "ethereum", "dogecoin"]
     api.config.TOP_COINS[:] = []
-    suggestions = api.suggest_coins("bitcin")
+    suggestions = await api.suggest_coins("bitcin")
     assert suggestions[0] == "bitcoin"
+
+
+@pytest.mark.asyncio
+async def test_suggest_coins_fallback():
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/search",
+            "GET",
+            Response(
+                text='{"coins": [{"id": "ripple", "symbol": "xrp", "name": "XRP"}]}',
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        api.config.COINS[:] = []
+        api.config.TOP_COINS[:] = []
+        suggestions = await api.suggest_coins("xrp")
+        assert suggestions == ["ripple"]


### PR DESCRIPTION
## Summary
- search remote coins when local search fails
- await suggestions in handlers
- test fallback search

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68780ac8ddc883218f1c40807f506074