### PR TITLE
Add cache tables for API data

### DIFF
--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -35,6 +35,7 @@ BOT_NAME = "PricePulseWatcherBot"
 DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
+CACHE_TTL = parse_duration(os.getenv("CACHE_TTL", "300s"))
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
 COINGECKO_BASE_URL = (

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -46,6 +46,7 @@ async def main() -> None:
         seconds=config.PRICE_CHECK_INTERVAL,
         args=(app,),
     )
+    scheduler.add_job(handlers.refresh_cache, "interval", minutes=5, args=(app,))
     scheduler.add_job(api.fetch_trending_coins, "interval", minutes=10)
     scheduler.add_job(api.fetch_top_coins, "interval", minutes=10)
     scheduler.start()


### PR DESCRIPTION
## Summary
- add `CACHE_TTL` configuration option
- store global market, coin info and chart data in SQLite
- refresh cached data for subscribed coins on a schedule

## Testing
- `isort .`
- `black .`
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687813f11c1083219820ce0aa6ae1669