### PR TITLE
Adjust logging for httpx

### DIFF
--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -65,4 +65,6 @@ logging.basicConfig(
     handlers=_handlers,
     force=True,
 )
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- reduce log noise from httpx by setting the logger level to WARNING

## Testing
- `flake8 pricepulsebot tests run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687818e973208321afdaa098bb129ed3