### PR TITLE
Cache trending coins

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -387,10 +387,7 @@ async def fetch_trending_coins() -> None:
         async with aiohttp.ClientSession() as session:
             resp = await api_get(url, session=session, headers=config.COINGECKO_HEADERS)
             if not resp or resp.status != 200:
-                config.logger.warning(
-                    "trending request failed: %s", getattr(resp, "status", "n/a")
-                )
-                return
+                raise RuntimeError(getattr(resp, "status", "n/a"))
             data = await resp.json()
             coins: list[str] = []
             for c in data.get("coins", [])[:10]:
@@ -404,8 +401,15 @@ async def fetch_trending_coins() -> None:
                         config.SYMBOL_TO_COIN[symbol.lower()] = coin_id
             if coins:
                 config.COINS = coins
+                await db.set_trending_coins(coins)
     except aiohttp.ClientError as exc:
         config.logger.error("error fetching trending coins: %s", exc)
+    except RuntimeError as err:
+        config.logger.warning("trending request failed: %s", err)
+    if not config.COINS:
+        cached = await db.get_trending_coins(max_age=config.CACHE_TTL)
+        if cached:
+            config.COINS = cached
 
 
 async def fetch_top_coins() -> None:

--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -51,6 +51,15 @@ async def init_db() -> None:
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trending_coins (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                data TEXT,
+                fetched_at REAL
+            )
+            """
+        )
         cursor = await db.execute("PRAGMA table_info(subscriptions)")
         rows = await cursor.fetchall()
         await cursor.close()
@@ -202,5 +211,27 @@ async def set_coin_chart(coin: str, days: int, data: list) -> None:
                 "VALUES (?, ?, ?, ?)"
             ),
             (coin, days, json.dumps(data), time.time()),
+        )
+        await db.commit()
+
+
+async def get_trending_coins(max_age: int = 300) -> Optional[list[str]]:
+    async with aiosqlite.connect(config.DB_FILE) as db:
+        cursor = await db.execute(
+            "SELECT data, fetched_at FROM trending_coins WHERE id=1"
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+    if row and time.time() - row[1] < max_age:
+        return json.loads(row[0])
+    return None
+
+
+async def set_trending_coins(coins: list[str]) -> None:
+    async with aiosqlite.connect(config.DB_FILE) as db:
+        await db.execute("DELETE FROM trending_coins WHERE id=1")
+        await db.execute(
+            "INSERT INTO trending_coins (id, data, fetched_at) VALUES (1, ?, ?)",
+            (json.dumps(coins), time.time()),
         )
         await db.commit()

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,0 +1,34 @@
+import pytest
+from aresponses import Response, ResponsesMockServer
+
+import pricepulsebot.api as api  # noqa: E402
+import pricepulsebot.config as config  # noqa: E402
+import pricepulsebot.db as db  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_fetch_trending_coins_cached(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/search/trending",
+            "GET",
+            Response(
+                text='{"coins": [{"item": {"id": "solana", "symbol": "sol"}}]}',
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        await api.fetch_trending_coins()
+    cached = await db.get_trending_coins()
+    assert cached == ["solana"]
+
+    async def fail(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(api, "api_get", fail)
+    config.COINS = []
+    await api.fetch_trending_coins()
+    assert config.COINS == ["solana"]


### PR DESCRIPTION
## Summary
- cache trending coins in DB
- fallback to cached trending coins when API errors
- test trending coin caching

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781bf3081483218a0ef581b71ac53f