### PR TITLE
Add DB cache for trending coins

### DIFF
--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -215,7 +215,7 @@ async def set_coin_chart(coin: str, days: int, data: list) -> None:
         await db.commit()
 
 
-async def get_trending_coins(max_age: int = 300) -> Optional[list[str]]:
+async def get_trending_coins(max_age: int = 300) -> Optional[list[dict]]:
     async with aiosqlite.connect(config.DB_FILE) as db:
         cursor = await db.execute(
             "SELECT data, fetched_at FROM trending_coins WHERE id=1"
@@ -227,7 +227,7 @@ async def get_trending_coins(max_age: int = 300) -> Optional[list[str]]:
     return None
 
 
-async def set_trending_coins(coins: list[str]) -> None:
+async def set_trending_coins(coins: list[dict]) -> None:
     async with aiosqlite.connect(config.DB_FILE) as db:
         await db.execute("DELETE FROM trending_coins WHERE id=1")
         await db.execute(

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -500,27 +500,22 @@ async def global_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 
 
 async def trends_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    await api.fetch_trending_coins()
-    if not config.COINS:
+    data = await api.fetch_trending_coins()
+    if not data:
         await update.message.reply_text(f"{ERROR_EMOJI} Failed to fetch data")
         return
     lines = []
-    async with aiohttp.ClientSession() as session:
-        for coin in config.COINS:
-            info = (
-                await api.get_market_info(
-                    coin, session=session, user=update.effective_chat.id
-                )
-                or {}
-            )
-            price = info.get("current_price")
-            change_24h = info.get("price_change_percentage_24h")
-            line = f"{api.symbol_for(coin)}"
-            if price is not None:
-                line += f" ${format_price(price)}"
-            if change_24h is not None:
-                line += f" ({change_24h:+.2f}% 24h)"
-            lines.append(line)
+    for item in data:
+        coin_id = item.get("id")
+        symbol = item.get("symbol") or api.symbol_for(coin_id)
+        line = f"{symbol.upper()}"
+        price = item.get("price")
+        change_24h = item.get("change_24h")
+        if price is not None:
+            line += f" ${format_price(price)}"
+        if change_24h is not None:
+            line += f" ({change_24h:+.2f}% 24h)"
+        lines.append(line)
     text = f"{INFO_EMOJI} Trending coins:\n" + "\n".join(lines)
     await update.message.reply_text(text)
 


### PR DESCRIPTION
## Summary
- cache full trending coin data in `trending_coins` table
- extend `fetch_trending_coins` to store price and change information
- use cached data in `/trends` handler
- adjust trending coin tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687823c9370c8321973835e7f738a8b3