### PR TITLE
Improve /valuearea handling of Binance symbols

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -26,6 +26,19 @@ def encoded(coin: str) -> str:
     return quote(coin, safe="-")
 
 
+async def resolve_pair(
+    value: str, quote: str = "USDT", *, user: Optional[int] = None
+) -> str:
+    """Return a Binance trading pair for a coin or symbol."""
+    pair = value.replace("/", "").upper()
+    quotes = ("USDT", "BUSD", "USDC", "USD", "BNB", "TRY", "EUR")
+    if any(pair.endswith(q) for q in quotes):
+        return pair
+    coin = await resolve_coin(value, user=user)
+    symbol = symbol_for(coin) if coin else pair
+    return f"{symbol}{quote}"
+
+
 async def suggest_coins(name: str, limit: int = 3) -> list[str]:
     candidates = list(
         {

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -526,7 +526,8 @@ async def valuearea_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             f"{ERROR_EMOJI} Usage: /valuearea <symbol> <interval> <count>"
         )
         return
-    symbol = context.args[0].upper()
+    symbol_input = context.args[0]
+    symbol = await api.resolve_pair(symbol_input, user=update.effective_chat.id)
     interval = context.args[1]
     try:
         limit = int(context.args[2])

--- a/tests/test_resolve_pair.py
+++ b/tests/test_resolve_pair.py
@@ -1,0 +1,34 @@
+import pytest
+
+import pricepulsebot.api as api  # noqa: E402
+
+resolve_pair = api.resolve_pair
+
+
+@pytest.mark.asyncio
+async def test_resolve_pair_existing_pair():
+    result = await resolve_pair("BTCUSDT")
+    assert result == "BTCUSDT"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pair_symbol(monkeypatch):
+    async def fake_resolve_coin(query, user=None):
+        return "bitcoin" if query == "btc" else None
+
+    monkeypatch.setattr(api, "resolve_coin", fake_resolve_coin)
+    api.config.COIN_SYMBOLS["bitcoin"] = "BTC"
+    api.config.SYMBOL_TO_COIN["btc"] = "bitcoin"
+    result = await resolve_pair("btc")
+    assert result == "BTCUSDT"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pair_coin_name(monkeypatch):
+    async def fake_resolve_coin(query, user=None):
+        return "bitcoin" if query == "bitcoin" else None
+
+    monkeypatch.setattr(api, "resolve_coin", fake_resolve_coin)
+    api.config.COIN_SYMBOLS["bitcoin"] = "BTC"
+    result = await resolve_pair("bitcoin")
+    assert result == "BTCUSDT"


### PR DESCRIPTION
## Summary
- add `resolve_pair` helper to build Binance trading pairs
- use it in `/valuearea` command
- cover new functionality with tests

## Testing
- `isort . && black . && flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878248f82b0832180539140f12db76b