### PR TITLE
Fix build_sub_entries error for invalid market data

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -367,7 +367,9 @@ async def build_sub_entries(chat_id: int) -> List[Tuple[str, str]]:
             info, _ = await api.get_coin_info(coin, user=chat_id)
         info = info or {}
         if market is None:
-            market = info.get("market_data", {})
+            market = info.get("market_data")
+            if not isinstance(market, dict):
+                market = {}
         if price is None:
             price = (
                 market.get("current_price", {}).get("usd")

--- a/tests/test_build_sub_entries.py
+++ b/tests/test_build_sub_entries.py
@@ -1,0 +1,31 @@
+import pytest
+
+import pricepulsebot.api as api
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+
+
+@pytest.mark.asyncio
+async def test_build_sub_entries_handles_non_dict_market_data(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+    await db.set_coin_data(
+        "bitcoin",
+        {
+            "price": 10.0,
+            "market_info": 0,
+            "info": {"symbol": "btc", "name": "Bitcoin", "market_data": 0},
+            "chart_7d": [],
+        },
+    )
+
+    async def fail(*args, **kwargs):
+        raise AssertionError("network called")
+
+    monkeypatch.setattr(api, "get_coin_info", fail)
+    monkeypatch.setattr(api, "get_price", fail)
+
+    entries = await handlers.build_sub_entries(1)
+    assert entries and entries[0][0] == "bitcoin"


### PR DESCRIPTION
## Summary
- handle case where `info['market_data']` is not a mapping in `build_sub_entries`
- add regression test for invalid market info

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b332ea008321acd890ae6a06c8bb