### PR TITLE
Fix trending arrow duplication

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -559,8 +559,7 @@ async def trends_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         if price is not None:
             line += f" ${format_price(price)}"
         if change_24h is not None:
-            arrow = UP_ARROW if change_24h >= 0 else DOWN_ARROW
-            line += f" {arrow} ({change_24h:+.2f}% 24h)"
+            line += f" ({change_24h:+.2f}% 24h)"
         lines.append(line)
     text = f"{INFO_EMOJI} Trending coins:\n" + "\n".join(lines)
     await update.message.reply_text(text)


### PR DESCRIPTION
## Summary
- only show change arrow at start of each trending coin

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878c44da57c8321baf5aefb896d6912