### PR TITLE
Handle invalid market data in /info

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -441,7 +441,9 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(f"{ERROR_EMOJI} No data available")
         return
     if market is None:
-        market = data.get("market_data", {})
+        market = data.get("market_data")
+        if not isinstance(market, dict):
+            market = {}
     price = market.get("current_price", {}).get("usd")
     cap = market.get("market_cap", {}).get("usd")
     change = market.get("price_change_percentage_24h")


### PR DESCRIPTION
## Summary
- fix `info_cmd` to ignore non-dict `market_data`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c7f1f97c8321a7101605319cedfa