### PR TITLE
Remove TTL from cache checks

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -185,7 +185,7 @@ async def get_coin_info(
     *,
     user: Optional[int] = None,
 ) -> tuple[Optional[dict], Optional[str]]:
-    cached = await db.get_coin_info(coin, max_age=config.CACHE_TTL)
+    cached = await db.get_coin_info(coin)
     if cached:
         return cached, None
     url = f"{config.COINGECKO_BASE_URL}/coins/{encoded(coin)}"
@@ -287,7 +287,7 @@ async def get_market_chart(
     *,
     user: Optional[int] = None,
 ) -> tuple[Optional[list[tuple[float, float]]], Optional[str]]:
-    cached = await db.get_coin_chart(coin, days, max_age=config.CACHE_TTL)
+    cached = await db.get_coin_chart(coin, days)
     if cached is not None:
         return [(p[0], p[1]) for p in cached], None
     end_ts = int(time.time())
@@ -322,7 +322,7 @@ async def get_global_overview(
     *,
     user: Optional[int] = None,
 ) -> tuple[Optional[dict], Optional[str]]:
-    cached = await db.get_global_data(max_age=config.CACHE_TTL)
+    cached = await db.get_global_data()
     if cached:
         return cached, None
     url = f"{config.COINGECKO_BASE_URL}/global"
@@ -454,7 +454,7 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
         config.logger.error("error fetching trending coins: %s", exc)
     except RuntimeError as err:
         config.logger.warning("trending request failed: %s", err)
-    cached = await db.get_trending_coins(max_age=config.CACHE_TTL)
+    cached = await db.get_trending_coins()
     if cached:
         for item in cached:
             coin_id = item.get("id")

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -35,7 +35,6 @@ BOT_NAME = "PricePulseWatcherBot"
 DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
-CACHE_TTL = parse_duration(os.getenv("CACHE_TTL", "300s"))
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
 COINGECKO_BASE_URL = (

--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -160,12 +160,12 @@ async def set_last_price(sub_id: int, price: float) -> None:
         await db.commit()
 
 
-async def get_global_data(max_age: int = 300) -> Optional[dict]:
+async def get_global_data() -> Optional[dict]:
     async with aiosqlite.connect(config.DB_FILE) as db:
         cursor = await db.execute("SELECT data, fetched_at FROM global_info WHERE id=1")
         row = await cursor.fetchone()
         await cursor.close()
-    if row and time.time() - row[1] < max_age:
+    if row:
         return json.loads(row[0])
     return None
 
@@ -180,7 +180,7 @@ async def set_global_data(data: dict) -> None:
         await db.commit()
 
 
-async def get_coin_info(coin: str, max_age: int = 300) -> Optional[dict]:
+async def get_coin_info(coin: str) -> Optional[dict]:
     async with aiosqlite.connect(config.DB_FILE) as db:
         cursor = await db.execute(
             "SELECT data, fetched_at FROM coin_info WHERE coin_id=?",
@@ -188,7 +188,7 @@ async def get_coin_info(coin: str, max_age: int = 300) -> Optional[dict]:
         )
         row = await cursor.fetchone()
         await cursor.close()
-    if row and time.time() - row[1] < max_age:
+    if row:
         return json.loads(row[0])
     return None
 
@@ -202,7 +202,7 @@ async def set_coin_info(coin: str, data: dict) -> None:
         await db.commit()
 
 
-async def get_coin_chart(coin: str, days: int, max_age: int = 300) -> Optional[list]:
+async def get_coin_chart(coin: str, days: int) -> Optional[list]:
     async with aiosqlite.connect(config.DB_FILE) as db:
         cursor = await db.execute(
             "SELECT data, fetched_at FROM coin_charts WHERE coin_id=? AND days=?",
@@ -210,7 +210,7 @@ async def get_coin_chart(coin: str, days: int, max_age: int = 300) -> Optional[l
         )
         row = await cursor.fetchone()
         await cursor.close()
-    if row and time.time() - row[1] < max_age:
+    if row:
         return json.loads(row[0])
     return None
 
@@ -227,14 +227,14 @@ async def set_coin_chart(coin: str, days: int, data: list) -> None:
         await db.commit()
 
 
-async def get_trending_coins(max_age: int = 300) -> Optional[list[dict]]:
+async def get_trending_coins() -> Optional[list[dict]]:
     async with aiosqlite.connect(config.DB_FILE) as db:
         cursor = await db.execute(
             "SELECT data, fetched_at FROM trending_coins WHERE id=1"
         )
         row = await cursor.fetchone()
         await cursor.close()
-    if row and time.time() - row[1] < max_age:
+    if row:
         return json.loads(row[0])
     return None
 
@@ -249,7 +249,7 @@ async def set_trending_coins(coins: list[dict]) -> None:
         await db.commit()
 
 
-async def get_coin_data(coin: str, max_age: int = 300) -> Optional[dict]:
+async def get_coin_data(coin: str) -> Optional[dict]:
     async with aiosqlite.connect(config.DB_FILE) as db:
         cursor = await db.execute(
             (
@@ -260,7 +260,7 @@ async def get_coin_data(coin: str, max_age: int = 300) -> Optional[dict]:
         )
         row = await cursor.fetchone()
         await cursor.close()
-    if row and time.time() - row[4] < max_age:
+    if row:
         price, market_json, info_json, chart_json, _ = row
         return {
             "price": price,

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -207,7 +207,7 @@ async def check_prices(app) -> None:
         prices: Dict[str, float] = {}
         missing: List[str] = []
         for coin in coins:
-            cached = await db.get_coin_data(coin, max_age=config.CACHE_TTL)
+            cached = await db.get_coin_data(coin)
             if cached and cached.get("price") is not None:
                 prices[coin] = float(cached["price"])
             else:
@@ -266,7 +266,7 @@ async def check_prices(app) -> None:
                             f"{symbol} moved {raw_change:+.2f}% in "
                             f"{config.format_interval(interval)} (now ${price}"
                         )
-                        cached = await db.get_coin_data(coin, max_age=config.CACHE_TTL)
+                        cached = await db.get_coin_data(coin)
                         info = cached.get("market_info") if cached else None
                         if info is None:
                             info = await api.get_market_info(coin, user=chat_id)
@@ -384,7 +384,7 @@ async def build_sub_entries(chat_id: int) -> List[Tuple[str, str]]:
     subs = await db.list_subscriptions(chat_id)
     entries: List[Tuple[str, str]] = []
     for _, coin, threshold, interval, *_ in subs:
-        cached = await db.get_coin_data(coin, max_age=config.CACHE_TTL)
+        cached = await db.get_coin_data(coin)
         info = cached.get("info") if cached else None
         market = cached.get("market_info") if cached else None
         if market is not None and not isinstance(market, dict):
@@ -451,7 +451,7 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             msg += f". Did you mean {syms}?"
         await update.message.reply_text(msg)
         return
-    cached = await db.get_coin_data(coin, max_age=config.CACHE_TTL)
+    cached = await db.get_coin_data(coin)
     data = cached.get("info") if cached else None
     market = cached.get("market_info") if cached else None
     if market is not None and not isinstance(market, dict):
@@ -505,7 +505,7 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except ValueError:
             await update.message.reply_text(f"{ERROR_EMOJI} Days must be a number")
             return
-    cached = await db.get_coin_data(coin, max_age=config.CACHE_TTL)
+    cached = await db.get_coin_data(coin)
     if days == 7 and cached and cached.get("chart_7d") is not None:
         data = [(p[0], p[1]) for p in cached["chart_7d"]]
         err = None


### PR DESCRIPTION
## Summary
- rely solely on the database for caching
- drop `CACHE_TTL`
- skip max_age checks when reading cached data

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878dbae9a688321a1f311bb419b9ca1