### PR TITLE
Handle invalid info data

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -386,6 +386,8 @@ async def build_sub_entries(chat_id: int) -> List[Tuple[str, str]]:
     for _, coin, threshold, interval, *_ in subs:
         cached = await db.get_coin_data(coin)
         info = cached.get("info") if cached else None
+        if info is not None and not isinstance(info, dict):
+            info = {}
         market = cached.get("market_info") if cached else None
         if market is not None and not isinstance(market, dict):
             market = None
@@ -453,6 +455,8 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     cached = await db.get_coin_data(coin)
     data = cached.get("info") if cached else None
+    if data is not None and not isinstance(data, dict):
+        data = None
     market = cached.get("market_info") if cached else None
     if market is not None and not isinstance(market, dict):
         market = None

--- a/tests/test_build_sub_entries.py
+++ b/tests/test_build_sub_entries.py
@@ -29,3 +29,28 @@ async def test_build_sub_entries_handles_non_dict_market_data(tmp_path, monkeypa
 
     entries = await handlers.build_sub_entries(1)
     assert entries and entries[0][0] == "bitcoin"
+
+
+@pytest.mark.asyncio
+async def test_build_sub_entries_handles_non_dict_info(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+    await db.set_coin_data(
+        "bitcoin",
+        {
+            "price": 10.0,
+            "market_info": {"current_price": 10.0},
+            "info": 0,
+            "chart_7d": [],
+        },
+    )
+
+    async def fail(*args, **kwargs):
+        raise AssertionError("network called")
+
+    monkeypatch.setattr(api, "get_coin_info", fail)
+    monkeypatch.setattr(api, "get_price", fail)
+
+    entries = await handlers.build_sub_entries(1)
+    assert entries and entries[0][0] == "bitcoin"


### PR DESCRIPTION
## Summary
- avoid AttributeError in `/list` when `info` data is invalid
- test build_sub_entries with invalid `info` data

## Testing
- `flake8 pricepulsebot tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e86f88d083219927979407a6349b