### PR TITLE
Fix flat market info handling

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -118,6 +118,15 @@ def trend_emojis(change: float) -> str:
     return UP_ARROW if change >= 0 else DOWN_ARROW
 
 
+def usd_value(value: Optional[object]) -> Optional[float]:
+    """Return the USD float when given either a number or a dict."""
+    if isinstance(value, dict):
+        return value.get("usd")
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
 def calculate_volume_profile(candles: List[dict]) -> dict:
     if not candles:
         raise ValueError("no candles provided")
@@ -403,11 +412,11 @@ async def build_sub_entries(chat_id: int) -> List[Tuple[str, str]]:
                 market = {}
         if price is None:
             price = (
-                market.get("current_price", {}).get("usd")
+                usd_value(market.get("current_price"))
                 or await api.get_price(coin, user=chat_id)
                 or 0
             )
-        cap = market.get("market_cap", {}).get("usd")
+        cap = usd_value(market.get("market_cap"))
         change_24h = market.get("price_change_percentage_24h")
         sym = info.get("symbol")
         if sym:
@@ -474,8 +483,8 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         market = data.get("market_data")
         if not isinstance(market, dict):
             market = {}
-    price = market.get("current_price", {}).get("usd")
-    cap = market.get("market_cap", {}).get("usd")
+    price = usd_value(market.get("current_price"))
+    cap = usd_value(market.get("market_cap"))
     change = market.get("price_change_percentage_24h")
     sym = data.get("symbol", "").upper()
     config.COIN_SYMBOLS[coin] = sym

--- a/tests/test_build_sub_entries.py
+++ b/tests/test_build_sub_entries.py
@@ -54,3 +54,32 @@ async def test_build_sub_entries_handles_non_dict_info(tmp_path, monkeypatch):
 
     entries = await handlers.build_sub_entries(1)
     assert entries and entries[0][0] == "bitcoin"
+
+
+@pytest.mark.asyncio
+async def test_build_sub_entries_handles_flat_market_info(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+    await db.set_coin_data(
+        "bitcoin",
+        {
+            "price": 10.0,
+            "market_info": {
+                "current_price": 10.0,
+                "market_cap": 1000,
+                "price_change_percentage_24h": 1.0,
+            },
+            "info": {"symbol": "btc", "name": "Bitcoin"},
+            "chart_7d": [],
+        },
+    )
+
+    async def fail(*args, **kwargs):
+        raise AssertionError("network called")
+
+    monkeypatch.setattr(api, "get_coin_info", fail)
+    monkeypatch.setattr(api, "get_price", fail)
+
+    entries = await handlers.build_sub_entries(1)
+    assert entries and entries[0][0] == "bitcoin"


### PR DESCRIPTION
## Summary
- handle market data where current price and market cap are numbers
- test build_sub_entries with flat market data

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f0492cc48321ab897e105e2ae775