### PR TITLE
Fix milestone message formatting

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -11,14 +11,8 @@ import aiohttp
 import numpy as np
 from matplotlib import dates as mdates
 from matplotlib import pyplot as plt
-from telegram import (
-    Bot,
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
-    KeyboardButton,
-    ReplyKeyboardMarkup,
-    Update,
-)
+from telegram import (Bot, InlineKeyboardButton, InlineKeyboardMarkup,
+                      KeyboardButton, ReplyKeyboardMarkup, Update)
 from telegram.constants import ChatAction
 from telegram.ext import ContextTypes
 
@@ -91,7 +85,12 @@ def milestone_step(price: float) -> float:
 
 
 def format_price(value: float) -> str:
-    return format(Decimal(str(value)), "f")
+    text = format(Decimal(str(value)), "f")
+    if "." in text:
+        frac = text.split(".")[1]
+        if len(frac) == 1:
+            text += "0"
+    return text
 
 
 def milestones_crossed(last: float, current: float) -> List[float]:
@@ -258,12 +257,18 @@ async def check_prices(app) -> None:
                 for level in milestones_crossed(prev, price):
                     symbol = api.symbol_for(coin)
                     if price > prev:
-                        msg = f"{symbol} breaks through ${level:.0f} (now ${price})"
+                        msg = (
+                            f"{symbol} breaks through ${format_price(level)} "
+                            f"(now ${format_price(price)})"
+                        )
                         await send_rate_limited(
                             app.bot, chat_id, msg, emoji=f"{UP_ARROW} {ROCKET}"
                         )
                     else:
-                        msg = f"{symbol} falls below ${level:.0f} (now ${price})"
+                        msg = (
+                            f"{symbol} falls below ${format_price(level)} "
+                            f"(now ${format_price(price)})"
+                        )
                         await send_rate_limited(
                             app.bot, chat_id, msg, emoji=f"{DOWN_ARROW} {BOMB}"
                         )

--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -1,4 +1,5 @@
-from pricepulsebot.handlers import milestone_step, milestones_crossed  # noqa: E402
+from pricepulsebot.handlers import (format_price, milestone_step,
+                                    milestones_crossed)
 
 
 def test_milestone_step():
@@ -21,3 +22,18 @@ def test_milestones_crossed_up():
 def test_milestones_crossed_down():
     levels = milestones_crossed(160.1, 159.8)
     assert levels == [160]
+
+
+def test_format_price_trailing_zero():
+    assert format_price(0.6) == "0.60"
+
+
+def test_format_price_small_value():
+    assert format_price(3.7e-05) == "0.000037"
+
+
+def test_milestone_message_format():
+    level = 0.6
+    price = 0.65
+    msg = f"BTC breaks through ${format_price(level)} " f"(now ${format_price(price)})"
+    assert msg == "BTC breaks through $0.60 (now $0.65)"


### PR DESCRIPTION
## Summary
- ensure prices show at least two decimals
- show milestone level with decimal precision
- test milestone formatting

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879047db1988321acca5b52437434d1