### PR TITLE
Batch price requests

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -11,8 +11,14 @@ import aiohttp
 import numpy as np
 from matplotlib import dates as mdates
 from matplotlib import pyplot as plt
-from telegram import (Bot, InlineKeyboardButton, InlineKeyboardMarkup,
-                      KeyboardButton, ReplyKeyboardMarkup, Update)
+from telegram import (
+    Bot,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+    Update,
+)
 from telegram.constants import ChatAction
 from telegram.ext import ContextTypes
 
@@ -223,20 +229,13 @@ async def check_prices(app) -> None:
             else:
                 missing.append(coin)
         if missing:
-            if len(missing) > 1:
-                groups = [
-                    missing[i : i + 250]  # noqa: E203
-                    for i in range(0, len(missing), 250)
-                ]
-                for group in groups:
-                    prices.update(
-                        await api.get_prices(group, session=http_session, user=None)
-                    )
-            else:
-                coin = missing[0]
-                price = await api.get_price(coin, user=None)
-                if price is not None:
-                    prices[coin] = price
+            groups = [
+                missing[i : i + 250] for i in range(0, len(missing), 250)  # noqa: E203
+            ]
+            for group in groups:
+                prices.update(
+                    await api.get_prices(group, session=http_session, user=None)
+                )
         for coin, subscriptions in by_coin.items():
             price = prices.get(coin)
             if price is None:

--- a/tests/test_coin_data.py
+++ b/tests/test_coin_data.py
@@ -78,7 +78,7 @@ async def test_check_prices_uses_cached_data(tmp_path, monkeypatch):
     async def fail(*args, **kwargs):
         raise AssertionError("network called")
 
-    monkeypatch.setattr(api, "get_price", fail)
+    monkeypatch.setattr(api, "get_prices", fail)
     monkeypatch.setattr(api, "get_market_info", fail)
 
     bot = DummyBot()

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -42,10 +42,10 @@ async def test_check_prices_interval_in_message(tmp_path, monkeypatch):
         )
         await conn.commit()
 
-    async def fake_price(coin, user=None):
-        return 105.0
+    async def fake_prices(coins, session=None, user=None):
+        return {c: 105.0 for c in coins}
 
-    monkeypatch.setattr(api, "get_price", fake_price)
+    monkeypatch.setattr(api, "get_prices", fake_prices)
     bot = DummyBot()
     app = DummyApp(bot)
     await handlers.check_prices(app)

--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -1,5 +1,4 @@
-from pricepulsebot.handlers import (format_price, milestone_step,
-                                    milestones_crossed)
+from pricepulsebot.handlers import format_price, milestone_step, milestones_crossed
 
 
 def test_milestone_step():


### PR DESCRIPTION
## Summary
- batch missing price lookups in `check_prices`
- adjust tests to mock `get_prices`

## Testing
- `isort .`
- `black .`
- `flake8`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879139d89b88321a2c4ea782e412f13