### PR TITLE
Add milestone alerts flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ DEFAULT_THRESHOLD=0.1
 DEFAULT_INTERVAL=5m
 # How often prices are checked
 PRICE_CHECK_INTERVAL=30s
+# Enable price milestone alerts (true/false)
+ENABLE_MILESTONE_ALERTS=true

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # LOG_FILE writes logs to the given file (default bot.log) and recreates it if removed
 # DEFAULT_THRESHOLD and DEFAULT_INTERVAL control new subscriptions
 # PRICE_CHECK_INTERVAL sets how often prices are fetched
+# ENABLE_MILESTONE_ALERTS toggles milestone notifications
 python run.py
 ```
 
@@ -46,6 +47,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `DEFAULT_THRESHOLD` – percent change that triggers an alert
 - `DEFAULT_INTERVAL` – subscription interval when none is given
 - `PRICE_CHECK_INTERVAL` – how often prices are checked
+- `ENABLE_MILESTONE_ALERTS` – send messages for price milestones
 
 ### Commands
 

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -36,6 +36,7 @@ BOT_NAME = "PricePulseWatcherBot"
 DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
+ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() == "true"
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
 COINGECKO_BASE_URL = (

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -253,24 +253,25 @@ async def check_prices(app) -> None:
                     MILESTONE_CACHE[(chat_id, coin)] = price
                     continue
                 prev = MILESTONE_CACHE.get((chat_id, coin), last_price)
-                for level in milestones_crossed(prev, price):
-                    symbol = api.symbol_for(coin)
-                    if price > prev:
-                        msg = (
-                            f"{symbol} breaks through ${format_price(level)} "
-                            f"(now ${format_price(price)})"
-                        )
-                        await send_rate_limited(
-                            app.bot, chat_id, msg, emoji=f"{UP_ARROW} {ROCKET}"
-                        )
-                    else:
-                        msg = (
-                            f"{symbol} falls below ${format_price(level)} "
-                            f"(now ${format_price(price)})"
-                        )
-                        await send_rate_limited(
-                            app.bot, chat_id, msg, emoji=f"{DOWN_ARROW} {BOMB}"
-                        )
+                if config.ENABLE_MILESTONE_ALERTS:
+                    for level in milestones_crossed(prev, price):
+                        symbol = api.symbol_for(coin)
+                        if price > prev:
+                            msg = (
+                                f"{symbol} breaks through ${format_price(level)} "
+                                f"(now ${format_price(price)})"
+                            )
+                            await send_rate_limited(
+                                app.bot, chat_id, msg, emoji=f"{UP_ARROW} {ROCKET}"
+                            )
+                        else:
+                            msg = (
+                                f"{symbol} falls below ${format_price(level)} "
+                                f"(now ${format_price(price)})"
+                            )
+                            await send_rate_limited(
+                                app.bot, chat_id, msg, emoji=f"{DOWN_ARROW} {BOMB}"
+                            )
                 MILESTONE_CACHE[(chat_id, coin)] = price
                 if last_ts is None or time.time() - last_ts >= interval:
                     raw_change = (price - last_price) / last_price * 100

--- a/tests/test_milestone_toggle.py
+++ b/tests/test_milestone_toggle.py
@@ -1,0 +1,51 @@
+import time
+
+import aiosqlite
+import pytest
+
+import pricepulsebot.api as api
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+from pricepulsebot.handlers import MILESTONE_CACHE
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+
+class DummyApp:
+    def __init__(self, bot):
+        self.bot = bot
+
+
+@pytest.mark.asyncio
+async def test_milestone_alerts_disabled(tmp_path, monkeypatch):
+    db_file = tmp_path / "subs.db"
+    config.DB_FILE = str(db_file)
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 0.1, 300)
+    async with aiosqlite.connect(config.DB_FILE) as conn:
+        await conn.execute(
+            "UPDATE subscriptions SET last_price=?, last_alert_ts=? WHERE id=1",
+            (100.0, time.time() - 600),
+        )
+        await conn.commit()
+
+    async def fake_prices(coins, session=None, user=None):
+        return {c: 110.0 for c in coins}
+
+    monkeypatch.setattr(api, "get_prices", fake_prices)
+    bot = DummyBot()
+    app = DummyApp(bot)
+    MILESTONE_CACHE.clear()
+    prev = config.ENABLE_MILESTONE_ALERTS
+    config.ENABLE_MILESTONE_ALERTS = False
+    await handlers.check_prices(app)
+    MILESTONE_CACHE.clear()
+    config.ENABLE_MILESTONE_ALERTS = prev
+    assert len(bot.sent) == 1


### PR DESCRIPTION
## Summary
- add `ENABLE_MILESTONE_ALERTS` setting
- document milestone toggle
- respect flag in `check_prices`
- test that milestone messages are skipped when disabled

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791da389ac8321bf1bac1adbe1b19a