### PR TITLE
Implement /milestones toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/chart <coin> [days]` – plot price history (alias `/charts`)
 - `/trends` – show trending coins
 - `/global` – show global market stats
-- `/milestones [on|off]` – toggle milestone notifications
+- `/milestones [on|off]` – toggle milestone notifications (no args switch)
 - `/settings [key value]` – show or change default settings
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -654,11 +654,10 @@ async def valuearea_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 
 async def milestones_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    state = "on" if config.ENABLE_MILESTONE_ALERTS else "off"
     if not context.args:
-        await update.message.reply_text(
-            f"{INFO_EMOJI} Milestone alerts are currently {state}"
-        )
+        config.ENABLE_MILESTONE_ALERTS = not config.ENABLE_MILESTONE_ALERTS
+        state = "enabled" if config.ENABLE_MILESTONE_ALERTS else "disabled"
+        await update.message.reply_text(f"{SUCCESS_EMOJI} Milestone alerts {state}")
         return
     arg = context.args[0].lower()
     if arg not in {"on", "off"}:

--- a/tests/test_milestones_cmd.py
+++ b/tests/test_milestones_cmd.py
@@ -24,9 +24,20 @@ class DummyContext:
 
 
 @pytest.mark.asyncio
-async def test_milestones_cmd_toggle():
+async def test_milestones_cmd_set_on():
     update = DummyUpdate()
     ctx = DummyContext(["on"])
+    prev = config.ENABLE_MILESTONE_ALERTS
+    config.ENABLE_MILESTONE_ALERTS = False
+    await handlers.milestones_cmd(update, ctx)
+    assert config.ENABLE_MILESTONE_ALERTS is True
+    config.ENABLE_MILESTONE_ALERTS = prev
+
+
+@pytest.mark.asyncio
+async def test_milestones_cmd_toggle():
+    update = DummyUpdate()
+    ctx = DummyContext([])
     prev = config.ENABLE_MILESTONE_ALERTS
     config.ENABLE_MILESTONE_ALERTS = False
     await handlers.milestones_cmd(update, ctx)


### PR DESCRIPTION
## Summary
- toggle milestone alerts when `/milestones` is used with no args
- document milestone toggling in README
- test toggling behaviour

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687929b419348321baf3e186d6df2f6c