### PR TITLE
Fix DB_PATH default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 TELEGRAM_TOKEN=
-# Path to the SQLite database file (defaults to subs.db)
-DB_PATH=./crypto.db
+# Path to the SQLite database file (defaults to crypto.db)
+DB_PATH=crypto.db
 # Optional CoinGecko API key
 COINGECKO_API_KEY=
 # Optional base URL for the CoinGecko API


### PR DESCRIPTION
## Summary
- correct DB_PATH example comment

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792b45537883219b99c45270636340