### PR TITLE
Allow custom headers for OHLCV fetch

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -217,6 +217,7 @@ async def fetch_ohlcv(
     limit: int,
     session: Optional[aiohttp.ClientSession] = None,
     *,
+    headers: Optional[dict] = None,
     user: Optional[int] = None,
 ) -> tuple[Optional[list[dict]], Optional[str]]:
     url = (
@@ -227,9 +228,7 @@ async def fetch_ohlcv(
     if owns_session:
         session = aiohttp.ClientSession()
     try:
-        resp = await api_get(
-            url, session=session, headers=config.COINGECKO_HEADERS, user=user
-        )
+        resp = await api_get(url, session=session, headers=headers, user=user)
         if not resp:
             return None, "request failed"
         if resp.status == 200:

--- a/tests/test_ohlcv.py
+++ b/tests/test_ohlcv.py
@@ -1,0 +1,49 @@
+import pytest
+
+import pricepulsebot.api as api  # noqa: E402
+import pricepulsebot.config as config  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_fetch_ohlcv_ignores_default_headers(monkeypatch):
+    captured = {}
+
+    async def fake_api_get(url, session=None, headers=None, user=None):
+        captured["headers"] = headers
+
+        class Resp:
+            status = 200
+
+            async def json(self):
+                return [[0, 0, 2, 1, 1.5, 100], [0, 0, 1.7, 1.5, 1.6, 300]]
+
+        return Resp()
+
+    monkeypatch.setattr(api, "api_get", fake_api_get)
+    config.COINGECKO_HEADERS = {"x-cg-pro-api-key": "TOKEN"}
+    candles, err = await api.fetch_ohlcv("BTCUSDT", "1h", 2, user=1)
+    assert err is None
+    assert len(candles) == 2
+    assert captured["headers"] is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_ohlcv_custom_headers(monkeypatch):
+    captured = {}
+
+    async def fake_api_get(url, session=None, headers=None, user=None):
+        captured["headers"] = headers
+
+        class Resp:
+            status = 200
+
+            async def json(self):
+                return []
+
+        return Resp()
+
+    monkeypatch.setattr(api, "api_get", fake_api_get)
+    headers = {"X-Test": "1"}
+    candles, err = await api.fetch_ohlcv("BTCUSDT", "1h", 0, headers=headers)
+    assert err is None
+    assert captured["headers"] == headers


### PR DESCRIPTION
## Summary
- allow specifying headers in `fetch_ohlcv`
- update to no longer send `COINGECKO_HEADERS`
- add tests covering default and custom header handling

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792b4da2d083219e6d686ad1154931