### PR TITLE
Optimize price checks with batched market calls

### DIFF
--- a/tests/test_coin_data.py
+++ b/tests/test_coin_data.py
@@ -78,7 +78,7 @@ async def test_check_prices_uses_cached_data(tmp_path, monkeypatch):
     async def fail(*args, **kwargs):
         raise AssertionError("network called")
 
-    monkeypatch.setattr(api, "get_prices", fail)
+    monkeypatch.setattr(api, "get_markets", fail)
     monkeypatch.setattr(api, "get_market_info", fail)
 
     bot = DummyBot()

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -42,10 +42,10 @@ async def test_check_prices_interval_in_message(tmp_path, monkeypatch):
         )
         await conn.commit()
 
-    async def fake_prices(coins, session=None, user=None):
-        return {c: 105.0 for c in coins}
+    async def fake_markets(coins, session=None, user=None):
+        return {c: {"current_price": 105.0} for c in coins}
 
-    monkeypatch.setattr(api, "get_prices", fake_prices)
+    monkeypatch.setattr(api, "get_markets", fake_markets)
     bot = DummyBot()
     app = DummyApp(bot)
     await handlers.check_prices(app)

--- a/tests/test_milestone_toggle.py
+++ b/tests/test_milestone_toggle.py
@@ -36,10 +36,10 @@ async def test_milestone_alerts_disabled(tmp_path, monkeypatch):
         )
         await conn.commit()
 
-    async def fake_prices(coins, session=None, user=None):
-        return {c: 110.0 for c in coins}
+    async def fake_markets(coins, session=None, user=None):
+        return {c: {"current_price": 110.0} for c in coins}
 
-    monkeypatch.setattr(api, "get_prices", fake_prices)
+    monkeypatch.setattr(api, "get_markets", fake_markets)
     bot = DummyBot()
     app = DummyApp(bot)
     MILESTONE_CACHE.clear()

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -47,3 +47,24 @@ async def test_get_prices_batch(monkeypatch):
         )
         prices = await get_prices(["bitcoin", "ethereum"])
         assert prices == {"bitcoin": 1.0, "ethereum": 2.0}
+
+
+@pytest.mark.asyncio
+async def test_get_markets_batch():
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/coins/markets",
+            "GET",
+            Response(
+                text=(
+                    '[{"id": "bitcoin", "current_price": 3.0},'
+                    '{"id": "ethereum", "current_price": 4.0}]'
+                ),
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        markets = await api.get_markets(["bitcoin", "ethereum"])
+        assert markets["bitcoin"]["current_price"] == 3.0
+        assert markets["ethereum"]["current_price"] == 4.0


### PR DESCRIPTION
## Summary
- add `get_markets` helper for multiple CoinGecko IDs
- fetch price and market info in one request in `check_prices`
- adjust tests to use the new batched API
- cover `get_markets` with unit tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794a3a0ca083218b79ccd143c91347