### PR TITLE
Add chart option for list and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 
 - `/add <coin> [pct] [interval]` – subscribe to price alerts
 - `/remove <coin>` – remove a subscription
-- `/list` – list active subscriptions
-- `/info <coin>` – show current coin data
+- `/list [full]` – list active subscriptions (full shows charts)
+- `/info <coin> [full]` – show current coin data (full adds chart)
 - `/chart <coin> [days]` – plot price history (alias `/charts`)
 - `/trends` – show trending coins
 - `/global` – show global market stats

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -138,6 +138,37 @@ def usd_value(value: Optional[object]) -> Optional[float]:
     return None
 
 
+async def create_chart_image(
+    coin: str, days: int, user_id: int
+) -> tuple[Optional[BytesIO], Optional[str]]:
+    """Return a PNG chart image for ``coin`` covering ``days``."""
+    cached = await db.get_coin_data(coin)
+    if days == 7 and cached and cached.get("chart_7d") is not None:
+        data = [(p[0], p[1]) for p in cached["chart_7d"]]
+        err = None
+    else:
+        data, err = await api.get_market_chart(coin, days, user=user_id)
+    if err:
+        return None, err
+    if not data:
+        return None, "No data available"
+    times, prices = zip(*data)
+    times = [datetime.fromtimestamp(t) for t in times]
+    plt.figure(figsize=(6, 3))
+    plt.plot(times, prices)
+    ax = plt.gca()
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+    plt.xlabel("Date")
+    plt.title(f"{coin.upper()} last {days} days")
+    plt.tight_layout()
+    buf = BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close()
+    buf.seek(0)
+    return buf, None
+
+
 def calculate_volume_profile(candles: List[dict]) -> dict:
     """Calculate the volume profile statistics for given candles."""
     if not candles:
@@ -471,6 +502,7 @@ async def list_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await context.bot.send_chat_action(
         chat_id=update.effective_chat.id, action=ChatAction.TYPING
     )
+    show_chart = len(context.args) > 0 and context.args[0].lower() == "full"
     entries = await build_sub_entries(update.effective_chat.id)
     if not entries:
         await update.message.reply_text(f"{INFO_EMOJI} No active subscriptions")
@@ -480,14 +512,21 @@ async def list_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             [[InlineKeyboardButton("Remove", callback_data=f"del:{coin}")]]
         )
         await update.message.reply_text(text, reply_markup=keyboard)
+        if show_chart:
+            buf, err = await create_chart_image(coin, 7, update.effective_chat.id)
+            if err:
+                await update.message.reply_text(f"{ERROR_EMOJI} {err}")
+                continue
+            await context.bot.send_photo(update.effective_chat.id, buf)
 
 
 async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Show detailed information about a coin."""
     if not context.args:
-        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /info <coin>")
+        await update.message.reply_text(f"{ERROR_EMOJI} Usage: /info <coin> [full]")
         return
     coin_input = context.args[0]
+    show_chart = len(context.args) > 1 and context.args[1].lower() == "full"
     coin = await api.resolve_coin(coin_input, user=update.effective_chat.id)
     if not coin:
         suggestions = await api.suggest_coins(coin_input)
@@ -530,6 +569,12 @@ async def info_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         cap,
     )
     await update.message.reply_text(text)
+    if show_chart:
+        buf, err = await create_chart_image(coin, 7, update.effective_chat.id)
+        if err:
+            await update.message.reply_text(f"{ERROR_EMOJI} {err}")
+        else:
+            await context.bot.send_photo(update.effective_chat.id, buf)
 
 
 async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -554,34 +599,10 @@ async def chart_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except ValueError:
             await update.message.reply_text(f"{ERROR_EMOJI} Days must be a number")
             return
-    cached = await db.get_coin_data(coin)
-    if days == 7 and cached and cached.get("chart_7d") is not None:
-        data = [(p[0], p[1]) for p in cached["chart_7d"]]
-        err = None
-    else:
-        data, err = await api.get_market_chart(
-            coin, days, user=update.effective_chat.id
-        )
+    buf, err = await create_chart_image(coin, days, update.effective_chat.id)
     if err:
         await update.message.reply_text(f"{ERROR_EMOJI} {err}")
         return
-    if not data:
-        await update.message.reply_text(f"{ERROR_EMOJI} No data available")
-        return
-    times, prices = zip(*data)
-    times = [datetime.fromtimestamp(t) for t in times]
-    plt.figure(figsize=(6, 3))
-    plt.plot(times, prices)
-    ax = plt.gca()
-    ax.xaxis.set_major_locator(mdates.AutoDateLocator())
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
-    plt.xlabel("Date")
-    plt.title(f"{coin.upper()} last {days} days")
-    plt.tight_layout()
-    buf = BytesIO()
-    plt.savefig(buf, format="png")
-    plt.close()
-    buf.seek(0)
     await context.bot.send_photo(update.effective_chat.id, buf)
 
 


### PR DESCRIPTION
## Summary
- support showing charts with `/list full`
- support showing charts with `/info <coin> full`
- update README with new syntax

## Testing
- `flake8`
- `isort .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687952792d448321b8425a8fb6662f64