### PR TITLE
Reuse shared HTTP session when refreshing cache

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -322,8 +322,9 @@ async def refresh_cache(app) -> None:
         cursor = await database.execute("SELECT DISTINCT coin_id FROM subscriptions")
         coins = [row[0] for row in await cursor.fetchall()]
         await cursor.close()
-    for coin in coins:
-        await api.refresh_coin_data(coin)
+    async with aiohttp.ClientSession() as session:
+        for coin in coins:
+            await api.refresh_coin_data(coin, session=session)
     await api.get_global_overview(user=None)
 
 

--- a/tests/test_coin_data.py
+++ b/tests/test_coin_data.py
@@ -1,5 +1,6 @@
 import time
 
+import aiohttp
 import aiosqlite
 import pytest
 
@@ -45,7 +46,8 @@ async def test_refresh_coin_data_populates_table(tmp_path, monkeypatch):
     monkeypatch.setattr(api, "get_coin_info", fake_coin_info)
     monkeypatch.setattr(api, "get_market_chart", fake_chart)
 
-    await api.refresh_coin_data("bitcoin")
+    async with aiohttp.ClientSession() as session:
+        await api.refresh_coin_data("bitcoin", session=session)
     data = await db.get_coin_data("bitcoin")
     assert data["price"] == 1.0
     assert data["market_info"]["current_price"] == 1.0


### PR DESCRIPTION
## Summary
- keep existing session when refreshing coin data
- share a ClientSession across coin refreshes
- update unit tests for new `refresh_coin_data` signature

## Testing
- `flake8`
- `pytest -q`
- `shellcheck install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68795a23c55c8321bf4c132bc9560a01