### PR TITLE
Add 3h window for API status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ percentage. Create a `.env` from the example and keep your
 
 ## Features
 
- - Subscribe to trending coins and get alerts
- - Suggest random coins from the top market cap list in the keyboard
+- Subscribe to trending coins and get alerts
+- Suggest random coins from the top market cap list in the keyboard
 - Autocompletion for all bot commands
+- Monitor API health with `/status` (last 3h)
 
 ## Quickstart
 
@@ -58,6 +59,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/chart <coin> [days]` – plot price history (alias `/charts`)
 - `/trends` – show trending coins
 - `/global` – show global market stats
+- `/status` – display API status overview (last 3h)
 - `/milestones [on|off]` – toggle milestone notifications (no args switch)
 - `/settings [key value]` – show or change default settings
 

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -358,6 +358,7 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "/chart(s) <coin> [days] - price chart\n"
         "/trends - show trending coins\n"
         "/global - global market stats\n"
+        "/status - API status overview (last 3h)\n"
         "/valuearea <symbol> <interval> <count> - volume profile\n"
         "Intervals can be like 1h, 15m or 30s",
         reply_markup=get_keyboard(),
@@ -756,6 +757,29 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         )
     else:
         await update.message.reply_text(f"{ERROR_EMOJI} Unknown setting '{key}'")
+
+
+async def status_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Show API request status counts and a status code chart."""
+    counts = api.status_counts()
+    if not counts:
+        await update.message.reply_text(f"{INFO_EMOJI} No API requests recorded")
+        return
+    codes = sorted(counts)
+    plt.figure(figsize=(4, 3))
+    plt.bar([str(c) for c in codes], [counts[c] for c in codes])
+    plt.xlabel("HTTP status")
+    plt.ylabel("Count")
+    plt.title("API responses last 3h")
+    plt.tight_layout()
+    buf = BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close()
+    buf.seek(0)
+    await context.bot.send_photo(update.effective_chat.id, buf)
+    lines = [f"{code}: {counts[code]}" for code in codes]
+    text = f"{INFO_EMOJI} API responses last 3h:\n" + "\n".join(lines)
+    await update.message.reply_text(text)
 
 
 async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -38,6 +38,7 @@ async def main() -> None:
     app.add_handler(CommandHandler("chart", handlers.chart_cmd))
     app.add_handler(CommandHandler("trends", handlers.trends_cmd))
     app.add_handler(CommandHandler("global", handlers.global_cmd))
+    app.add_handler(CommandHandler("status", handlers.status_cmd))
     app.add_handler(CommandHandler("valuearea", handlers.valuearea_cmd))
     app.add_handler(CommandHandler("milestones", handlers.milestones_cmd))
     app.add_handler(CommandHandler("settings", handlers.settings_cmd))
@@ -68,6 +69,7 @@ async def main() -> None:
             BotCommand("chart", "Price chart"),
             BotCommand("trends", "Trending coins"),
             BotCommand("global", "Global market"),
+            BotCommand("status", "API status"),
             BotCommand("valuearea", "Volume profile"),
             BotCommand("milestones", "Toggle milestone alerts"),
             BotCommand("settings", "Show or change defaults"),

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -1,0 +1,57 @@
+import time
+
+import pytest
+
+import pricepulsebot.api as api
+import pricepulsebot.handlers as handlers
+
+
+class DummyBot:
+    def __init__(self):
+        self.photos = []
+
+    async def send_photo(self, chat_id, photo):
+        self.photos.append((chat_id, photo))
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, bot):
+        self.bot = bot
+        self.args = []
+
+
+@pytest.mark.asyncio
+async def test_status_cmd_basic():
+    api.STATUS_HISTORY.clear()
+    now = time.time()
+    api.STATUS_HISTORY.extend(
+        [
+            (now - api.STATUS_WINDOW - 1, 200),
+            (now - 1800, 429),
+            (now - 10, 500),
+        ]
+    )
+    bot = DummyBot()
+    update = DummyUpdate()
+    ctx = DummyContext(bot)
+    await handlers.status_cmd(update, ctx)
+    assert bot.photos
+    assert update.message.texts
+    counts = api.status_counts()
+    assert 200 not in counts
+    assert counts[429] == 1
+    assert counts[500] == 1


### PR DESCRIPTION
## Summary
- track API responses only for the last 3 hours
- display 3h window in `/status` command output
- document 3h API status window in README
- test filtering logic for old status entries

## Testing
- `isort . && black . && flake8 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687950088390832189b548422de0d056