### PR TITLE
Implement coin news support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/list` – list active subscriptions
 - `/info <coin>` – show current coin data
 - `/chart <coin> [days]` – plot price history (alias `/charts`)
+- `/news [coin]` – show latest news (uses subscriptions when omitted)
 - `/trends` – show trending coins
 - `/global` – show global market stats
 - `/status` – display API status overview

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -36,6 +36,7 @@ async def main() -> None:
     app.add_handler(CommandHandler("list", handlers.list_cmd))
     app.add_handler(CommandHandler("info", handlers.info_cmd))
     app.add_handler(CommandHandler("chart", handlers.chart_cmd))
+    app.add_handler(CommandHandler("news", handlers.news_cmd))
     app.add_handler(CommandHandler("trends", handlers.trends_cmd))
     app.add_handler(CommandHandler("global", handlers.global_cmd))
     app.add_handler(CommandHandler("status", handlers.status_cmd))
@@ -67,6 +68,7 @@ async def main() -> None:
             BotCommand("list", "List subscriptions"),
             BotCommand("info", "Coin information"),
             BotCommand("chart", "Price chart"),
+            BotCommand("news", "Latest news"),
             BotCommand("trends", "Trending coins"),
             BotCommand("global", "Global market"),
             BotCommand("status", "API status"),

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,60 @@
+import pytest
+from aresponses import Response, ResponsesMockServer
+
+import pricepulsebot.api as api
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+
+
+@pytest.mark.asyncio
+async def test_get_news_basic():
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "min-api.cryptocompare.com",
+            "/data/v2/news/",
+            "GET",
+            Response(
+                text='{"Data": [{"title": "Hello"}]}',
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        news = await api.get_news("bitcoin")
+        assert news and news[0]["title"] == "Hello"
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+
+
+@pytest.mark.asyncio
+async def test_news_cmd_subscriptions(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+
+    async def fake_news(coin, session=None, user=None):
+        return [{"title": "Hello"}]
+
+    monkeypatch.setattr(api, "get_news", fake_news)
+
+    update = DummyUpdate()
+    ctx = DummyContext([])
+    await handlers.news_cmd(update, ctx)
+    assert update.message.texts


### PR DESCRIPTION
## Summary
- add `/news` command and underlying `get_news` API
- register the command in the application and help text
- document the `/news` command in README
- test retrieving news via CryptoCompare API
- test the `/news` command when no coin is specified

## Testing
- `isort .`
- `black .`
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795abd211c83218dd6fb75c6aee4de