### PR TITLE
Implement absolute price alerts

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -216,17 +216,47 @@ async def check_prices(app) -> None:
     async with aiohttp.ClientSession() as http_session:
         async with db.aiosqlite.connect(config.DB_FILE) as database:
             cursor = await database.execute(
-                "SELECT id, chat_id, coin_id, threshold, interval, last_price, "
-                "last_alert_ts FROM subscriptions"
+                "SELECT id, chat_id, coin_id, threshold, interval, target_price, direction, last_price, last_alert_ts FROM subscriptions"
             )
             rows = await cursor.fetchall()
             await cursor.close()
         by_coin: Dict[
-            str, List[Tuple[int, int, float, int, Optional[float], Optional[float]]]
+            str,
+            List[
+                Tuple[
+                    int,
+                    int,
+                    float,
+                    int,
+                    Optional[float],
+                    Optional[int],
+                    Optional[float],
+                    Optional[float],
+                ]
+            ],
         ] = {}
-        for sub_id, chat_id, coin, threshold, interval, last_price, last_ts in rows:
+        for (
+            sub_id,
+            chat_id,
+            coin,
+            threshold,
+            interval,
+            target_price,
+            direction,
+            last_price,
+            last_ts,
+        ) in rows:
             by_coin.setdefault(coin, []).append(
-                (sub_id, chat_id, threshold, interval, last_price, last_ts)
+                (
+                    sub_id,
+                    chat_id,
+                    threshold,
+                    interval,
+                    target_price,
+                    direction,
+                    last_price,
+                    last_ts,
+                )
             )
         coins = list(by_coin.keys())
         prices: Dict[str, float] = {}
@@ -264,6 +294,8 @@ async def check_prices(app) -> None:
                 chat_id,
                 threshold,
                 interval,
+                target_price,
+                direction,
                 last_price,
                 last_ts,
             ) in subscriptions:
@@ -292,6 +324,27 @@ async def check_prices(app) -> None:
                                 app.bot, chat_id, msg, emoji=f"{DOWN_ARROW} {BOMB}"
                             )
                 MILESTONE_CACHE[(chat_id, coin)] = price
+                if target_price is not None and direction is not None:
+                    crossed_up = direction > 0 and prev < target_price <= price
+                    crossed_down = direction < 0 and prev > target_price >= price
+                    if crossed_up or crossed_down:
+                        symbol = api.symbol_for(coin)
+                        if crossed_up:
+                            msg = (
+                                f"{symbol} reached ${format_price(target_price)} "
+                                f"(now ${format_price(price)})"
+                            )
+                            await send_rate_limited(
+                                app.bot, chat_id, msg, emoji=f"{UP_ARROW} {ROCKET}"
+                            )
+                        elif crossed_down:
+                            msg = (
+                                f"{symbol} fell below ${format_price(target_price)} "
+                                f"(now ${format_price(price)})"
+                            )
+                            await send_rate_limited(
+                                app.bot, chat_id, msg, emoji=f"{DOWN_ARROW} {BOMB}"
+                            )
                 if last_ts is None or time.time() - last_ts >= interval:
                     raw_change = (price - last_price) / last_price * 100
                     change = abs(raw_change)
@@ -382,18 +435,34 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             msg += f". Did you mean {syms}?"
         await update.message.reply_text(msg)
         return
-    try:
-        threshold = (
-            float(context.args[1])
-            if len(context.args) > 1
-            else config.DEFAULT_THRESHOLD
-        )
-    except ValueError:
-        await update.message.reply_text(f"{ERROR_EMOJI} Threshold must be a number")
-        return
+    target_price = None
+    direction = None
+    threshold = config.DEFAULT_THRESHOLD
+    arg_idx = 1
+    if len(context.args) > 1:
+        arg = context.args[1]
+        if arg and arg[0] in {">", "<"}:
+            try:
+                target_price = float(arg[1:])
+            except ValueError:
+                await update.message.reply_text(f"{ERROR_EMOJI} Invalid target price")
+                return
+            direction = 1 if arg[0] == ">" else -1
+            arg_idx = 2
+        else:
+            try:
+                threshold = float(arg)
+            except ValueError:
+                await update.message.reply_text(
+                    f"{ERROR_EMOJI} Threshold must be a number"
+                )
+                return
+            arg_idx = 2
     try:
         interval_str = (
-            context.args[2] if len(context.args) > 2 else str(config.DEFAULT_INTERVAL)
+            context.args[arg_idx]
+            if len(context.args) > arg_idx
+            else str(config.DEFAULT_INTERVAL)
         )
         interval = config.parse_duration(interval_str)
     except ValueError:
@@ -401,7 +470,14 @@ async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             f"{ERROR_EMOJI} Interval must be a number or like 1h, 15m, 30s"
         )
         return
-    await db.subscribe_coin(update.effective_chat.id, coin, threshold, interval)
+    await db.subscribe_coin(
+        update.effective_chat.id,
+        coin,
+        threshold,
+        interval,
+        target_price,
+        direction,
+    )
     await update.message.reply_text(
         f"{SUB_EMOJI} Subscribed to {api.symbol_for(coin)}",
         reply_markup=get_keyboard(),

--- a/tests/test_target_price.py
+++ b/tests/test_target_price.py
@@ -1,0 +1,47 @@
+import time
+
+import aiosqlite
+import pytest
+
+import pricepulsebot.api as api
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+from pricepulsebot.handlers import MILESTONE_CACHE
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+
+class DummyApp:
+    def __init__(self, bot):
+        self.bot = bot
+
+
+@pytest.mark.asyncio
+async def test_absolute_price_alert(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 0.1, 300, 110.0, 1)
+    async with aiosqlite.connect(config.DB_FILE) as conn:
+        await conn.execute(
+            "UPDATE subscriptions SET last_price=?, last_alert_ts=? WHERE id=1",
+            (100.0, time.time() - 600),
+        )
+        await conn.commit()
+
+    async def fake_markets(coins, session=None, user=None):
+        return {c: {"current_price": 111.0} for c in coins}
+
+    monkeypatch.setattr(api, "get_markets", fake_markets)
+    bot = DummyBot()
+    app = DummyApp(bot)
+    MILESTONE_CACHE.clear()
+    await handlers.check_prices(app)
+    MILESTONE_CACHE.clear()
+    assert any("reached" in msg for _, msg in bot.sent)


### PR DESCRIPTION
## Summary
- extend database schema to store `target_price` and `direction`
- handle new columns in DB migrations and subscription logic
- parse optional absolute price in `/add` command
- trigger alerts when absolute targets are crossed
- cover absolute price alerts in tests

## Testing
- `isort .`
- `black .`
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795b097c588321b6c08446de70223a