### PR TITLE
Add clear command to remove subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 
 - `/add <coin> [pct] [interval]` – subscribe to price alerts
 - `/remove <coin>` – remove a subscription
+- `/clear` – remove all subscriptions
 - `/list` – list active subscriptions
 - `/info <coin>` – show current coin data
 - `/chart <coin> [days]` – plot price history (alias `/charts`)

--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -140,6 +140,14 @@ async def unsubscribe_coin(chat_id: int, coin: str) -> None:
     config.logger.info("chat %s unsubscribed from %s", chat_id, coin)
 
 
+async def unsubscribe_all(chat_id: int) -> None:
+    """Remove all subscriptions for ``chat_id``."""
+    async with aiosqlite.connect(config.DB_FILE) as db:
+        await db.execute("DELETE FROM subscriptions WHERE chat_id=?", (chat_id,))
+        await db.commit()
+    config.logger.info("chat %s cleared all subscriptions", chat_id)
+
+
 async def list_subscriptions(
     chat_id: int,
 ) -> List[Tuple[int, str, float, int, Optional[float], Optional[float]]]:

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -421,6 +421,15 @@ async def unsubscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     )
 
 
+async def clear_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Remove all subscriptions for the chat."""
+    await db.unsubscribe_all(update.effective_chat.id)
+    await update.message.reply_text(
+        f"{SUCCESS_EMOJI} Removed all subscriptions",
+        reply_markup=get_keyboard(),
+    )
+
+
 async def build_sub_entries(chat_id: int) -> List[Tuple[str, str]]:
     """Return formatted subscription entries for ``chat_id``."""
     subs = await db.list_subscriptions(chat_id)

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -33,6 +33,7 @@ async def main() -> None:
     app.add_handler(CommandHandler("help", handlers.help_cmd))
     app.add_handler(CommandHandler("add", handlers.subscribe_cmd))
     app.add_handler(CommandHandler("remove", handlers.unsubscribe_cmd))
+    app.add_handler(CommandHandler("clear", handlers.clear_cmd))
     app.add_handler(CommandHandler("list", handlers.list_cmd))
     app.add_handler(CommandHandler("info", handlers.info_cmd))
     app.add_handler(CommandHandler("chart", handlers.chart_cmd))
@@ -64,6 +65,7 @@ async def main() -> None:
             BotCommand("help", "Show help"),
             BotCommand("add", "Subscribe to price alerts"),
             BotCommand("remove", "Remove subscription"),
+            BotCommand("clear", "Remove all subscriptions"),
             BotCommand("list", "List subscriptions"),
             BotCommand("info", "Coin information"),
             BotCommand("chart", "Price chart"),

--- a/tests/test_unsubscribe_all.py
+++ b/tests/test_unsubscribe_all.py
@@ -1,0 +1,49 @@
+import pytest
+
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_all(tmp_path):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 0.1, 60)
+    await db.subscribe_coin(1, "ethereum", 0.1, 60)
+    await db.unsubscribe_all(1)
+    subs = await db.list_subscriptions(1)
+    assert subs == []
+
+
+@pytest.mark.asyncio
+async def test_clear_cmd(tmp_path):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 0.1, 60)
+    await db.subscribe_coin(1, "ethereum", 0.1, 60)
+    update = DummyUpdate()
+    ctx = DummyContext()
+    await handlers.clear_cmd(update, ctx)
+    subs = await db.list_subscriptions(1)
+    assert subs == []
+    assert update.message.texts


### PR DESCRIPTION
## Summary
- add `unsubscribe_all` to delete all rows for a chat
- implement `/clear` command
- register command and document usage
- add tests for clearing subscriptions

## Testing
- `isort . && black . && flake8 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795b29b2b08321b67261ad1c7b2ece