### PR TITLE
Allow session reuse in refresh_coin_data

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -777,9 +777,11 @@ async def get_news(
     return None
 
 
-async def refresh_coin_data(coin: str) -> None:
-
+async def refresh_coin_data(
+    coin: str, session: Optional[aiohttp.ClientSession] = None
+) -> None:
     """Refresh cached price, market info and chart data for ``coin``."""
+
     owns_session = session is None
     if owns_session:
         session = aiohttp.ClientSession()


### PR DESCRIPTION
## Summary
- support passing an optional aiohttp session to `refresh_coin_data`
- use the passed session when refreshing cached data

## Testing
- `PYTHONPATH=. pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68796c537fc08321b44f4dd769335ae1