### PR TITLE
Add liquidation alerts feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,7 @@ DEFAULT_INTERVAL=5m
 PRICE_CHECK_INTERVAL=30s
 # Enable price milestone alerts (true/false)
 ENABLE_MILESTONE_ALERTS=true
+# Enable liquidation alerts (true/false)
+ENABLE_LIQUIDATION_ALERTS=false
 # Default currency used when fetching prices
 DEFAULT_VS_CURRENCY=usd

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ percentage. Create a `.env` from the example and keep your
 - Autocompletion for all bot commands
 - Monitor API health with `/status`
 - Check recent coin news via `/news` (CryptoCompare)
+- Optional futures liquidation alerts
 
 ## Quickstart
 
@@ -29,6 +30,7 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # DEFAULT_THRESHOLD and DEFAULT_INTERVAL control new subscriptions
 # PRICE_CHECK_INTERVAL sets how often prices are fetched
 # ENABLE_MILESTONE_ALERTS toggles milestone notifications
+# ENABLE_LIQUIDATION_ALERTS toggles futures liquidation alerts
 # DEFAULT_VS_CURRENCY sets the reference currency used for prices
 python run.py
 ```
@@ -51,6 +53,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `DEFAULT_INTERVAL` – subscription interval when none is given
 - `PRICE_CHECK_INTERVAL` – how often prices are checked
 - `ENABLE_MILESTONE_ALERTS` – send messages for price milestones
+- `ENABLE_LIQUIDATION_ALERTS` – enable liquidation event alerts
 - `DEFAULT_VS_CURRENCY` – default currency used for API requests
 
 ### Commands
@@ -67,7 +70,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/status` – display API status overview
 - `/milestones [on|off]` – toggle milestone notifications (no args switch)
 - `/settings [key value]` – show or change default settings (threshold,
-  interval, milestones, currency)
+  interval, milestones, liquidations, currency)
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.
 

--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -777,8 +777,9 @@ async def get_news(
     return None
 
 
-async def refresh_coin_data(coin: str) -> None:
-
+async def refresh_coin_data(
+    coin: str, *, session: aiohttp.ClientSession | None = None
+) -> None:
     """Refresh cached price, market info and chart data for ``coin``."""
     owns_session = session is None
     if owns_session:

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -43,6 +43,9 @@ DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
 ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() == "true"
+ENABLE_LIQUIDATION_ALERTS = (
+    os.getenv("ENABLE_LIQUIDATION_ALERTS", "false").lower() == "true"
+)
 VS_CURRENCY = os.getenv("DEFAULT_VS_CURRENCY", "usd").lower()
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -833,13 +833,14 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             f"- interval: {config.format_interval(config.DEFAULT_INTERVAL)}\n"
             f"- pricecheck: {config.format_interval(config.PRICE_CHECK_INTERVAL)}\n"
             f"- milestones: {'on' if config.ENABLE_MILESTONE_ALERTS else 'off'}\n"
+            f"- liquidations: {'on' if config.ENABLE_LIQUIDATION_ALERTS else 'off'}\n"
             f"- currency: {config.VS_CURRENCY}"
         )
         await update.message.reply_text(text)
         return
     if len(context.args) < 2:
         await update.message.reply_text(
-            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|currency> <value>"
+            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|liquidations|currency> <value>"
         )
         return
     key = context.args[0].lower()
@@ -875,6 +876,16 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         config.ENABLE_MILESTONE_ALERTS = val == "on"
         state = "enabled" if config.ENABLE_MILESTONE_ALERTS else "disabled"
         await update.message.reply_text(f"{SUCCESS_EMOJI} Milestone alerts {state}")
+    elif key == "liquidations":
+        val = value.lower()
+        if val not in {"on", "off"}:
+            await update.message.reply_text(
+                f"{ERROR_EMOJI} Liquidations must be on or off"
+            )
+            return
+        config.ENABLE_LIQUIDATION_ALERTS = val == "on"
+        state = "enabled" if config.ENABLE_LIQUIDATION_ALERTS else "disabled"
+        await update.message.reply_text(f"{SUCCESS_EMOJI} Liquidation alerts {state}")
     elif key == "currency":
         config.VS_CURRENCY = value.lower()
         await update.message.reply_text(

--- a/pricepulsebot/liquidations.py
+++ b/pricepulsebot/liquidations.py
@@ -1,0 +1,43 @@
+"""Fetch and broadcast large futures liquidation events."""
+
+from __future__ import annotations
+
+import aiohttp
+
+from . import config, db
+from .handlers import send_rate_limited
+
+
+async def check_liquidations(app) -> None:
+    """Poll Binance for large liquidation orders and alert subscribers."""
+    url = "https://fapi.binance.com/futures/data/forceOrders?limit=50"
+    async with aiohttp.ClientSession() as session:
+        resp = await session.get(url)
+        if resp.status != 200:
+            config.logger.warning("liquidation API status %s", resp.status)
+            return
+        data = await resp.json()
+
+    events: list[str] = []
+    for item in data:
+        price = float(item.get("price", 0))
+        qty = float(item.get("origQty") or item.get("qty") or 0)
+        usd = price * qty
+        if usd < 500_000:
+            continue
+        side = item.get("side", "")
+        direction = "long" if side == "SELL" else "short"
+        symbol = item.get("symbol", "")
+        events.append(f"{symbol} {direction} liquidation ~${usd:,.0f}")
+
+    if not events:
+        return
+
+    async with db.aiosqlite.connect(config.DB_FILE) as database:
+        cursor = await database.execute("SELECT DISTINCT chat_id FROM subscriptions")
+        chats = [row[0] for row in await cursor.fetchall()]
+        await cursor.close()
+
+    for chat_id in chats:
+        for text in events:
+            await send_rate_limited(app.bot, chat_id, text, emoji="\u26a0\ufe0f")

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -14,7 +14,7 @@ from telegram.ext import (
     filters,
 )
 
-from . import api, config, db, handlers
+from . import api, config, db, handlers, liquidations
 
 
 async def main() -> None:
@@ -54,6 +54,10 @@ async def main() -> None:
         seconds=config.PRICE_CHECK_INTERVAL,
         args=(app,),
     )
+    if config.ENABLE_LIQUIDATION_ALERTS:
+        scheduler.add_job(
+            liquidations.check_liquidations, "interval", minutes=1, args=(app,)
+        )
     scheduler.add_job(handlers.refresh_cache, "interval", minutes=5, args=(app,))
     scheduler.add_job(api.fetch_trending_coins, "interval", minutes=10)
     scheduler.add_job(api.fetch_top_coins, "interval", minutes=10)

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -54,6 +54,16 @@ async def test_settings_update_milestones():
 
 
 @pytest.mark.asyncio
+async def test_settings_update_liquidations():
+    update = DummyUpdate()
+    ctx = DummyContext(["liquidations", "on"])
+    prev = config.ENABLE_LIQUIDATION_ALERTS
+    await handlers.settings_cmd(update, ctx)
+    assert config.ENABLE_LIQUIDATION_ALERTS is True
+    config.ENABLE_LIQUIDATION_ALERTS = prev
+
+
+@pytest.mark.asyncio
 async def test_settings_pricecheck_readonly():
     update = DummyUpdate()
     ctx = DummyContext(["pricecheck", "30s"])


### PR DESCRIPTION
## Summary
- notify chats of large futures liquidations via new module
- make liquidation alerts configurable
- expose `/settings liquidations on|off`
- document liquidation alert feature

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796bbec1f4832196b865a3a9f7eb41