### PR TITLE
Add volume alert feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ LOG_LEVEL=INFO
 LOG_FILE=bot.log
 # Default percent change that triggers an alert
 DEFAULT_THRESHOLD=0.1
+# Percent change in 24h volume that triggers an alert
+VOLUME_THRESHOLD=
 # Default subscription interval when none is specified
 DEFAULT_INTERVAL=5m
 # How often prices are checked

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ percentage. Create a `.env` from the example and keep your
 - Autocompletion for all bot commands
 - Monitor API health with `/status`
 - Check recent coin news via `/news` (CryptoCompare)
+- Get alerts when trading volume spikes or drops
 
 ## Quickstart
 
@@ -27,6 +28,7 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # LOG_LEVEL enables verbose output when set to DEBUG
 # LOG_FILE writes logs to the given file (default bot.log) and recreates it if removed
 # DEFAULT_THRESHOLD and DEFAULT_INTERVAL control new subscriptions
+# VOLUME_THRESHOLD sets the volume change percentage for alerts
 # PRICE_CHECK_INTERVAL sets how often prices are fetched
 # ENABLE_MILESTONE_ALERTS toggles milestone notifications
 # DEFAULT_VS_CURRENCY sets the reference currency used for prices
@@ -48,6 +50,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `LOG_FILE` – file to write logs to (recreated if removed)
 
 - `DEFAULT_THRESHOLD` – percent change that triggers an alert
+- `VOLUME_THRESHOLD` – 24h volume change that triggers an alert
 - `DEFAULT_INTERVAL` – subscription interval when none is given
 - `PRICE_CHECK_INTERVAL` – how often prices are checked
 - `ENABLE_MILESTONE_ALERTS` – send messages for price milestones

--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -18,6 +18,7 @@ from aiolimiter import AsyncLimiter
 from . import config, db
 
 PRICE_CACHE: Dict[str, Tuple[float, float]] = {}
+VOLUME_CACHE: Dict[str, Tuple[float, float]] = {}
 COINGECKO_LIMITER = AsyncLimiter(30, 60)
 LAST_KNOWN_PRICE: Dict[str, float] = {}
 STATUS_WINDOW = 3 * 3600  # 3 hours
@@ -226,6 +227,42 @@ async def get_price(
     return LAST_KNOWN_PRICE.get(coin)
 
 
+async def get_volume(
+    coin: str,
+    session: Optional[aiohttp.ClientSession] = None,
+    *,
+    user: Optional[int] = None,
+) -> Optional[float]:
+    """Return the current 24h volume for ``coin``."""
+    now = time.time()
+    cached = VOLUME_CACHE.get(coin)
+    if cached and now - cached[1] < 60:
+        return cached[0]
+
+    url = (
+        f"{config.COINGECKO_BASE_URL}/coins/{encoded(coin)}/market_chart"
+        f"?vs_currency={config.VS_CURRENCY}&days=1"
+    )
+    headers = config.COINGECKO_HEADERS
+    owns_session = session is None
+    if owns_session:
+        session = aiohttp.ClientSession()
+    try:
+        resp = await api_get(url, session=session, headers=headers, user=user)
+        if not resp or resp.status != 200:
+            return None
+        data = await resp.json()
+        volumes = data.get("total_volumes") or []
+        if not volumes:
+            return None
+        volume = float(volumes[-1][1])
+        VOLUME_CACHE[coin] = (volume, time.time())
+        return volume
+    finally:
+        if owns_session and session:
+            await session.close()
+
+
 async def get_prices(
     coins: list[str],
     session: Optional[aiohttp.ClientSession] = None,
@@ -249,7 +286,10 @@ async def get_prices(
         Mapping of coin ID to its current price.
     """
     ids = ",".join(encoded(c) for c in coins)
-    url = f"{config.COINGECKO_BASE_URL}/simple/price?ids={ids}&vs_currencies={config.VS_CURRENCY}"
+    url = (
+        f"{config.COINGECKO_BASE_URL}/simple/price"
+        f"?ids={ids}&vs_currencies={config.VS_CURRENCY}"
+    )
     retries = 3
     owns_session = session is None
     if owns_session:
@@ -447,7 +487,8 @@ async def get_market_info(
     """Return market data for ``coin`` such as price and 24h change."""
     url = (
         f"{config.COINGECKO_BASE_URL}/coins/markets"
-        f"?vs_currency={config.VS_CURRENCY}&ids={encoded(coin)}&price_change_percentage=24h"
+        f"?vs_currency={config.VS_CURRENCY}&ids={encoded(coin)}"
+        f"&price_change_percentage=24h"
     )
     headers = config.COINGECKO_HEADERS
     owns_session = session is None
@@ -669,7 +710,8 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
             if ids:
                 markets_url = (
                     f"{config.COINGECKO_BASE_URL}/coins/markets"
-                    f"?vs_currency={config.VS_CURRENCY}&ids={','.join(ids)}&price_change_percentage=24h"
+                    f"?vs_currency={config.VS_CURRENCY}&ids={','.join(ids)}"
+                    f"&price_change_percentage=24h"
                 )
                 market_resp = await api_get(
                     markets_url, session=session, headers=config.COINGECKO_HEADERS
@@ -777,8 +819,9 @@ async def get_news(
     return None
 
 
-async def refresh_coin_data(coin: str) -> None:
-
+async def refresh_coin_data(
+    coin: str, session: Optional[aiohttp.ClientSession] = None
+) -> None:
     """Refresh cached price, market info and chart data for ``coin``."""
     owns_session = session is None
     if owns_session:

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -40,6 +40,7 @@ def format_interval(seconds: int) -> str:
 DB_FILE = os.getenv("DB_PATH", "subs.db")
 BOT_NAME = "PricePulseWatcherBot"
 DEFAULT_THRESHOLD = float(os.getenv("DEFAULT_THRESHOLD", "0.1"))
+VOLUME_THRESHOLD = float(os.getenv("VOLUME_THRESHOLD", str(DEFAULT_THRESHOLD)))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
 ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() == "true"

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -216,7 +216,11 @@ async def check_prices(app) -> None:
     async with aiohttp.ClientSession() as http_session:
         async with db.aiosqlite.connect(config.DB_FILE) as database:
             cursor = await database.execute(
-                "SELECT id, chat_id, coin_id, threshold, interval, target_price, direction, last_price, last_alert_ts FROM subscriptions"
+                (
+                    "SELECT id, chat_id, coin_id, threshold, interval, "
+                    "target_price, direction, last_price, last_volume, "
+                    "last_alert_ts FROM subscriptions"
+                )
             )
             rows = await cursor.fetchall()
             await cursor.close()
@@ -232,6 +236,7 @@ async def check_prices(app) -> None:
                     Optional[int],
                     Optional[float],
                     Optional[float],
+                    Optional[float],
                 ]
             ],
         ] = {}
@@ -244,6 +249,7 @@ async def check_prices(app) -> None:
             target_price,
             direction,
             last_price,
+            last_volume,
             last_ts,
         ) in rows:
             by_coin.setdefault(coin, []).append(
@@ -255,6 +261,7 @@ async def check_prices(app) -> None:
                     target_price,
                     direction,
                     last_price,
+                    last_volume,
                     last_ts,
                 )
             )
@@ -285,10 +292,16 @@ async def check_prices(app) -> None:
                     if price is not None:
                         prices[c] = float(price)
                     infos[c] = info
+        volumes: Dict[str, float] = {}
+        for coin in coins:
+            vol = await api.get_volume(coin, session=http_session, user=None)
+            if vol is not None:
+                volumes[coin] = vol
         for coin, subscriptions in by_coin.items():
             price = prices.get(coin)
             if price is None:
                 continue
+            volume = volumes.get(coin)
             for (
                 sub_id,
                 chat_id,
@@ -297,10 +310,11 @@ async def check_prices(app) -> None:
                 target_price,
                 direction,
                 last_price,
+                last_volume,
                 last_ts,
             ) in subscriptions:
                 if last_price is None:
-                    await db.set_last_price(sub_id, price)
+                    await db.set_last_price(sub_id, price, volume)
                     MILESTONE_CACHE[(chat_id, coin)] = price
                     continue
                 prev = MILESTONE_CACHE.get((chat_id, coin), last_price)
@@ -366,7 +380,25 @@ async def check_prices(app) -> None:
                         await send_rate_limited(
                             app.bot, chat_id, text, emoji=trend_emojis(raw_change)
                         )
-                    await db.set_last_price(sub_id, price)
+                    if (
+                        volume is not None
+                        and last_volume is not None
+                        and last_volume > 0
+                    ):
+                        raw_vol_change = (volume - last_volume) / last_volume * 100
+                        if abs(raw_vol_change) >= config.VOLUME_THRESHOLD:
+                            symbol = api.symbol_for(coin)
+                            msg = (
+                                f"{symbol} volume {raw_vol_change:+.2f}% "
+                                f"(24h {volume:,.0f})"
+                            )
+                            await send_rate_limited(
+                                app.bot,
+                                chat_id,
+                                msg,
+                                emoji=trend_emojis(raw_vol_change),
+                            )
+                    await db.set_last_price(sub_id, price, volume)
 
 
 async def refresh_cache(app) -> None:
@@ -839,7 +871,10 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     if len(context.args) < 2:
         await update.message.reply_text(
-            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|currency> <value>"
+            (
+                f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|"
+                "currency> <value>"
+            )
         )
         return
     key = context.args[0].lower()

--- a/tests/test_volume_alerts.py
+++ b/tests/test_volume_alerts.py
@@ -1,0 +1,87 @@
+import time
+
+import aiosqlite
+import pytest
+
+import pricepulsebot.api as api
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+from pricepulsebot.handlers import MILESTONE_CACHE
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+
+class DummyApp:
+    def __init__(self, bot):
+        self.bot = bot
+
+
+@pytest.mark.asyncio
+async def test_volume_spike_alert(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    config.VOLUME_THRESHOLD = 10.0
+    await db.subscribe_coin(1, "bitcoin", 0.1, 300)
+    async with aiosqlite.connect(config.DB_FILE) as conn:
+        await conn.execute(
+            (
+                "UPDATE subscriptions SET last_price=?, last_volume=?, "
+                "last_alert_ts=? WHERE id=1"
+            ),
+            (100.0, 1000.0, time.time() - 600),
+        )
+        await conn.commit()
+
+    async def fake_markets(coins, session=None, user=None):
+        return {c: {"current_price": 101.0} for c in coins}
+
+    async def fake_volume(coin, session=None, user=None):
+        return 1500.0
+
+    monkeypatch.setattr(api, "get_markets", fake_markets)
+    monkeypatch.setattr(api, "get_volume", fake_volume)
+    bot = DummyBot()
+    app = DummyApp(bot)
+    MILESTONE_CACHE.clear()
+    await handlers.check_prices(app)
+    MILESTONE_CACHE.clear()
+    assert any("volume" in msg for _, msg in bot.sent)
+
+
+@pytest.mark.asyncio
+async def test_volume_drop_alert(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    config.VOLUME_THRESHOLD = 10.0
+    await db.subscribe_coin(1, "bitcoin", 0.1, 300)
+    async with aiosqlite.connect(config.DB_FILE) as conn:
+        await conn.execute(
+            (
+                "UPDATE subscriptions SET last_price=?, last_volume=?, "
+                "last_alert_ts=? WHERE id=1"
+            ),
+            (100.0, 1000.0, time.time() - 600),
+        )
+        await conn.commit()
+
+    async def fake_markets(coins, session=None, user=None):
+        return {c: {"current_price": 99.0} for c in coins}
+
+    async def fake_volume(coin, session=None, user=None):
+        return 500.0
+
+    monkeypatch.setattr(api, "get_markets", fake_markets)
+    monkeypatch.setattr(api, "get_volume", fake_volume)
+    bot = DummyBot()
+    app = DummyApp(bot)
+    MILESTONE_CACHE.clear()
+    await handlers.check_prices(app)
+    MILESTONE_CACHE.clear()
+    assert any("volume" in msg for _, msg in bot.sent)


### PR DESCRIPTION
## Summary
- add `VOLUME_THRESHOLD` setting
- implement `get_volume` helper using CoinGecko market chart
- track last volume in the database
- alert when 24h volume changes beyond threshold
- document new setting and provide tests for volume alerts

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68796b14e5188321aae6570b59091c27