### PR TITLE
Add fear & greed index command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/news [coin]` – show latest news (uses subscriptions when omitted)
 - `/trends` – show trending coins
 - `/global` – show global market stats
+- `/feargreed` – show daily market sentiment
 - `/status` – display API status overview
 - `/milestones [on|off]` – toggle milestone notifications (no args switch)
 - `/settings [key value]` – show or change default settings (threshold,

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -216,7 +216,11 @@ async def check_prices(app) -> None:
     async with aiohttp.ClientSession() as http_session:
         async with db.aiosqlite.connect(config.DB_FILE) as database:
             cursor = await database.execute(
-                "SELECT id, chat_id, coin_id, threshold, interval, target_price, direction, last_price, last_alert_ts FROM subscriptions"
+                (
+                    "SELECT id, chat_id, coin_id, threshold, interval, "
+                    "target_price, direction, last_price, last_alert_ts "
+                    "FROM subscriptions"
+                )
             )
             rows = await cursor.fetchall()
             await cursor.close()
@@ -413,6 +417,7 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "/news [coin] - latest news\n"
         "/trends - show trending coins\n"
         "/global - global market stats\n"
+        "/feargreed - market sentiment\n"
         "/status - API status overview\n"
         "/valuearea <symbol> <interval> <count> - volume profile\n"
         "Intervals can be like 1h, 15m or 30s",
@@ -704,6 +709,35 @@ async def global_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     await update.message.reply_text(text)
 
 
+async def feargreed_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Display the daily Fear & Greed Index."""
+    data, err = await api.get_feargreed_index(user=update.effective_chat.id)
+    if err:
+        await update.message.reply_text(f"{ERROR_EMOJI} {err}")
+        return
+    if not data:
+        await update.message.reply_text(f"{ERROR_EMOJI} Failed to fetch data")
+        return
+    value_str = data.get("value")
+    classification = data.get("value_classification")
+    try:
+        value = int(value_str)
+    except (TypeError, ValueError):
+        value = None
+    if value is None:
+        emoji = INFO_EMOJI
+    elif value < 40:
+        emoji = "\U0001f534"  # red
+    elif value < 60:
+        emoji = "\U0001f7e1"  # yellow
+    else:
+        emoji = "\U0001f7e2"  # green
+    text = f"{emoji} Fear & Greed Index: {value_str}"
+    if classification:
+        text += f" ({classification})"
+    await update.message.reply_text(text)
+
+
 async def trends_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Display the current trending coins."""
     data = await api.fetch_trending_coins()
@@ -839,7 +873,8 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     if len(context.args) < 2:
         await update.message.reply_text(
-            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|currency> <value>"
+            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|"
+            f"currency> <value>"
         )
         return
     key = context.args[0].lower()

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -40,6 +40,7 @@ async def main() -> None:
     app.add_handler(CommandHandler("news", handlers.news_cmd))
     app.add_handler(CommandHandler("trends", handlers.trends_cmd))
     app.add_handler(CommandHandler("global", handlers.global_cmd))
+    app.add_handler(CommandHandler(["feargreed", "sentiment"], handlers.feargreed_cmd))
     app.add_handler(CommandHandler("status", handlers.status_cmd))
     app.add_handler(CommandHandler("valuearea", handlers.valuearea_cmd))
     app.add_handler(CommandHandler("milestones", handlers.milestones_cmd))
@@ -73,6 +74,7 @@ async def main() -> None:
             BotCommand("news", "Latest news"),
             BotCommand("trends", "Trending coins"),
             BotCommand("global", "Global market"),
+            BotCommand("feargreed", "Market sentiment"),
             BotCommand("status", "API status"),
             BotCommand("valuearea", "Volume profile"),
             BotCommand("milestones", "Toggle milestone alerts"),

--- a/tests/test_feargreed.py
+++ b/tests/test_feargreed.py
@@ -1,0 +1,78 @@
+import pytest
+from aresponses import Response, ResponsesMockServer
+
+import pricepulsebot.api as api
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+
+
+@pytest.mark.asyncio
+async def test_get_feargreed_basic(tmp_path):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.alternative.me",
+            "/fng/",
+            "GET",
+            Response(
+                text='{"data": [{"value": "55", "value_classification": "Greed"}]}',
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        data, err = await api.get_feargreed_index()
+    cached = await db.get_feargreed()
+    assert err is None
+    assert data == cached
+    assert data["value"] == "55"
+
+
+@pytest.mark.asyncio
+async def test_get_feargreed_uses_cache(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    cached = {"value": "30", "value_classification": "Fear"}
+    await db.set_feargreed(cached)
+
+    async def fail(*args, **kwargs):
+        raise AssertionError("network called")
+
+    monkeypatch.setattr(api, "api_get", fail)
+    data, err = await api.get_feargreed_index()
+    assert err is None
+    assert data == cached
+
+
+@pytest.mark.asyncio
+async def test_feargreed_cmd(monkeypatch):
+    async def fake(*args, **kwargs):
+        return {"value": "70", "value_classification": "Greed"}, None
+
+    monkeypatch.setattr(api, "get_feargreed_index", fake)
+
+    update = DummyUpdate()
+    ctx = DummyContext()
+    await handlers.feargreed_cmd(update, ctx)
+    assert update.message.texts
+    assert "70" in update.message.texts[0]


### PR DESCRIPTION
## Summary
- cache fear & greed API results in SQLite
- fetch fear & greed index from alternative.me
- show market sentiment via `/feargreed` command
- register the new command and document it
- test sentiment fetching and handler output

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796be970c08321aeacfccff8bb5ffd