### PR TITLE
Apply code formatting and resolve lint errors

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -249,7 +249,10 @@ async def get_prices(
         Mapping of coin ID to its current price.
     """
     ids = ",".join(encoded(c) for c in coins)
-    url = f"{config.COINGECKO_BASE_URL}/simple/price?ids={ids}&vs_currencies={config.VS_CURRENCY}"
+    url = (
+        f"{config.COINGECKO_BASE_URL}/simple/price"
+        f"?ids={ids}&vs_currencies={config.VS_CURRENCY}"
+    )
     retries = 3
     owns_session = session is None
     if owns_session:
@@ -447,7 +450,8 @@ async def get_market_info(
     """Return market data for ``coin`` such as price and 24h change."""
     url = (
         f"{config.COINGECKO_BASE_URL}/coins/markets"
-        f"?vs_currency={config.VS_CURRENCY}&ids={encoded(coin)}&price_change_percentage=24h"
+        f"?vs_currency={config.VS_CURRENCY}"
+        f"&ids={encoded(coin)}&price_change_percentage=24h"
     )
     headers = config.COINGECKO_HEADERS
     owns_session = session is None
@@ -669,7 +673,8 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
             if ids:
                 markets_url = (
                     f"{config.COINGECKO_BASE_URL}/coins/markets"
-                    f"?vs_currency={config.VS_CURRENCY}&ids={','.join(ids)}&price_change_percentage=24h"
+                    f"?vs_currency={config.VS_CURRENCY}"
+                    f"&ids={','.join(ids)}&price_change_percentage=24h"
                 )
                 market_resp = await api_get(
                     markets_url, session=session, headers=config.COINGECKO_HEADERS
@@ -777,8 +782,9 @@ async def get_news(
     return None
 
 
-async def refresh_coin_data(coin: str) -> None:
-
+async def refresh_coin_data(
+    coin: str, session: Optional[aiohttp.ClientSession] = None
+) -> None:
     """Refresh cached price, market info and chart data for ``coin``."""
     owns_session = session is None
     if owns_session:

--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -121,14 +121,17 @@ async def subscribe_coin(
             new_price = target_price if target_price is not None else existing_price
             new_dir = direction if direction is not None else existing_dir
             await db.execute(
-                "UPDATE subscriptions SET threshold=?, interval=?, target_price=?, direction=? WHERE id=?",
+                (
+                    "UPDATE subscriptions SET threshold=?, interval=?, target_price=?, "
+                    "direction=? WHERE id=?"
+                ),
                 (new_th, new_int, new_price, new_dir, sub_id),
             )
         else:
             await db.execute(
                 (
-                    "INSERT INTO subscriptions (chat_id, coin_id, threshold, interval, target_price, direction)"
-                    " VALUES (?, ?, ?, ?, ?, ?)"
+                    "INSERT INTO subscriptions (chat_id, coin_id, threshold, interval, "
+                    "target_price, direction) VALUES (?, ?, ?, ?, ?, ?)"
                 ),
                 (chat_id, coin, threshold, interval, target_price, direction),
             )

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -216,7 +216,10 @@ async def check_prices(app) -> None:
     async with aiohttp.ClientSession() as http_session:
         async with db.aiosqlite.connect(config.DB_FILE) as database:
             cursor = await database.execute(
-                "SELECT id, chat_id, coin_id, threshold, interval, target_price, direction, last_price, last_alert_ts FROM subscriptions"
+                (
+                    "SELECT id, chat_id, coin_id, threshold, interval, target_price, "
+                    "direction, last_price, last_alert_ts FROM subscriptions"
+                )
             )
             rows = await cursor.fetchall()
             await cursor.close()
@@ -839,7 +842,8 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     if len(context.args) < 2:
         await update.message.reply_text(
-            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|currency> <value>"
+            f"{ERROR_EMOJI} Usage: /settings <threshold|interval|milestones|currency>"
+            " <value>"
         )
         return
     key = context.args[0].lower()


### PR DESCRIPTION
## Summary
- break long lines in API, DB and handler modules
- add optional session parameter to `refresh_coin_data`
- wrap SQL and help text for readability
- format with isort and black

## Testing
- `isort --profile black --check .`
- `black --check .`
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796bffa1ec8321a3c426314a5074ab