### PR TITLE
Centralize command list

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -44,6 +44,26 @@ INFO_EMOJI = "\u2139\ufe0f"
 SUCCESS_EMOJI = "\u2705"
 ERROR_EMOJI = "\u26a0\ufe0f"
 
+# (name, description) pairs used for help text and bot registration
+COMMANDS: list[tuple[str, str]] = [
+    ("add", "Subscribe to price alerts"),
+    ("chart", "Price chart"),
+    ("clear", "Remove all subscriptions"),
+    ("feargreed", "Market sentiment"),
+    ("global", "Global market"),
+    ("help", "Show help"),
+    ("info", "Coin information"),
+    ("list", "List subscriptions"),
+    ("milestones", "Toggle milestone alerts"),
+    ("news", "Latest news"),
+    ("remove", "Remove subscription"),
+    ("settings", "Show or change defaults"),
+    ("start", "Show menu"),
+    ("status", "API status"),
+    ("trends", "Trending coins"),
+    ("valuearea", "Volume profile"),
+]
+
 
 def format_coin_text(
     name: str,
@@ -435,20 +455,10 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Display available commands and usage information."""
+    lines = [f"/{name} - {desc}" for name, desc in COMMANDS]
+    lines.append("Intervals can be like 1h, 15m or 30s")
     await update.message.reply_text(
-        f"{INFO_EMOJI} /add <coin> [pct] [interval] - subscribe to price alerts\n"
-        "/remove <coin> - remove subscription\n"
-        "/list - list subscriptions\n"
-        "/info <coin> - coin information\n"
-        "/chart(s) <coin> [days] - price chart\n"
-        "/news [coin] - latest news\n"
-        "/trends - show trending coins\n"
-        "/global - global market stats\n"
-        "/feargreed - market sentiment\n"
-        "/status - API status overview\n"
-        "/valuearea <symbol> <interval> <count> - volume profile\n"
-        "Intervals can be like 1h, 15m or 30s",
-        reply_markup=get_keyboard(),
+        f"{INFO_EMOJI} " + "\n".join(lines), reply_markup=get_keyboard()
     )
 
 

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -66,24 +66,7 @@ async def main() -> None:
 
     await app.initialize()
     await app.bot.set_my_commands(
-        [
-            BotCommand("start", "Show menu"),
-            BotCommand("help", "Show help"),
-            BotCommand("add", "Subscribe to price alerts"),
-            BotCommand("remove", "Remove subscription"),
-            BotCommand("clear", "Remove all subscriptions"),
-            BotCommand("list", "List subscriptions"),
-            BotCommand("info", "Coin information"),
-            BotCommand("chart", "Price chart"),
-            BotCommand("news", "Latest news"),
-            BotCommand("trends", "Trending coins"),
-            BotCommand("global", "Global market"),
-            BotCommand("feargreed", "Market sentiment"),
-            BotCommand("status", "API status"),
-            BotCommand("valuearea", "Volume profile"),
-            BotCommand("milestones", "Toggle milestone alerts"),
-            BotCommand("settings", "Show or change defaults"),
-        ]
+        [BotCommand(name, desc) for name, desc in handlers.COMMANDS]
     )
     await app.start()
     await app.updater.start_polling()


### PR DESCRIPTION
## Summary
- keep an ordered `COMMANDS` list describing all bot commands
- generate help text from the `COMMANDS` list
- build `BotCommand` objects from the same list

## Testing
- `flake8`
- `pytest -q` *(fails: ValueError: not enough values to unpack)*

------
https://chatgpt.com/codex/tasks/task_e_6879770efdf48321a197048575d18d65