### PR TITLE
Add reply keyboard settings menu

### DIFF
--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -1,0 +1,56 @@
+import pytest
+
+import pricepulsebot.config as config
+import pricepulsebot.handlers as handlers
+from pricepulsebot.handlers import BACK_EMOJI, SETTINGS_EMOJI, ReplyKeyboardMarkup
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.texts = []
+        self.markups = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+
+
+class DummyUpdate:
+    def __init__(self, text=""):
+        self.message = DummyMessage(text)
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+
+
+def test_keyboard_has_settings_button():
+    kb = handlers.get_keyboard()
+    assert kb.keyboard[1][1].text == SETTINGS_EMOJI
+
+
+@pytest.mark.asyncio
+async def test_settings_menu_toggle_and_back():
+    prev = config.DEFAULT_THRESHOLD
+    update = DummyUpdate(SETTINGS_EMOJI)
+    ctx = DummyContext()
+    await handlers.menu(update, ctx)
+    assert update.message.markups and isinstance(
+        update.message.markups[-1], ReplyKeyboardMarkup
+    )
+
+    update.message.text = f"threshold: ±{config.DEFAULT_THRESHOLD}%"
+    await handlers.menu(update, ctx)
+    assert config.DEFAULT_THRESHOLD != prev
+    assert isinstance(update.message.markups[-1], ReplyKeyboardMarkup)
+
+    update.message.text = f"{BACK_EMOJI} Back"
+    await handlers.menu(update, ctx)
+    kb = update.message.markups[-1]
+    assert isinstance(kb, ReplyKeyboardMarkup)
+    assert kb.keyboard[1][1].text == SETTINGS_EMOJI
+
+    config.DEFAULT_THRESHOLD = prev


### PR DESCRIPTION
## Summary
- integrate gear button in main keyboard
- provide reply keyboard menu for settings
- toggle settings via `menu` handler
- add tests for new settings menu

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797d0b699c832192b7f6f77db85842