### PR TITLE
Add volume alerts toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ DEFAULT_INTERVAL=5m
 PRICE_CHECK_INTERVAL=30s
 # Enable price milestone alerts (true/false)
 ENABLE_MILESTONE_ALERTS=true
+# Enable volume alerts (true/false)
+ENABLE_VOLUME_ALERTS=true
 # Enable liquidation alerts (true/false)
 ENABLE_LIQUIDATION_ALERTS=false
 # Default currency used when fetching prices

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cp .env.example .env             # edit TELEGRAM_TOKEN
 # VOLUME_THRESHOLD sets the volume change percentage for alerts
 # PRICE_CHECK_INTERVAL sets how often prices are fetched
 # ENABLE_MILESTONE_ALERTS toggles milestone notifications
+# ENABLE_VOLUME_ALERTS toggles volume alerts
 # ENABLE_LIQUIDATION_ALERTS toggles futures liquidation alerts
 # DEFAULT_VS_CURRENCY sets the reference currency used for prices
 python run.py
@@ -55,6 +56,7 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `DEFAULT_INTERVAL` – subscription interval when none is given
 - `PRICE_CHECK_INTERVAL` – how often prices are checked
 - `ENABLE_MILESTONE_ALERTS` – send messages for price milestones
+- `ENABLE_VOLUME_ALERTS` – enable volume change alerts
 - `ENABLE_LIQUIDATION_ALERTS` – enable liquidation event alerts
 - `DEFAULT_VS_CURRENCY` – default currency used for API requests
 
@@ -73,7 +75,8 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/status` – display API status overview
 - `/milestones [on|off]` – toggle milestone notifications (no args switch)
 - `/settings [key value]` – show or change default settings (threshold,
-  interval, milestones, liquidations, currency)
+ `/settings [key value]` – show or change default settings (threshold,
+  interval, milestones, volume, liquidations, currency)
 
 Intervals accept plain seconds or values like `1h`, `15m` or `30s`.
 

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -47,6 +47,7 @@ ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() =
 ENABLE_LIQUIDATION_ALERTS = (
     os.getenv("ENABLE_LIQUIDATION_ALERTS", "false").lower() == "true"
 )
+ENABLE_VOLUME_ALERTS = os.getenv("ENABLE_VOLUME_ALERTS", "true").lower() == "true"
 VS_CURRENCY = os.getenv("DEFAULT_VS_CURRENCY", "usd").lower()
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -13,8 +13,14 @@ import aiohttp
 import numpy as np
 from matplotlib import dates as mdates
 from matplotlib import pyplot as plt
-from telegram import (Bot, InlineKeyboardButton, InlineKeyboardMarkup,
-                      KeyboardButton, ReplyKeyboardMarkup, Update)
+from telegram import (
+    Bot,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+    Update,
+)
 from telegram.constants import ChatAction
 from telegram.ext import ContextTypes
 
@@ -307,10 +313,11 @@ async def check_prices(app) -> None:
                         prices[c] = float(price)
                     infos[c] = info
         volumes: Dict[str, float] = {}
-        for coin in coins:
-            vol = await api.get_volume(coin, session=http_session, user=None)
-            if vol is not None:
-                volumes[coin] = vol
+        if config.ENABLE_VOLUME_ALERTS:
+            for coin in coins:
+                vol = await api.get_volume(coin, session=http_session, user=None)
+                if vol is not None:
+                    volumes[coin] = vol
         for coin, subscriptions in by_coin.items():
             price = prices.get(coin)
             if price is None:
@@ -394,24 +401,25 @@ async def check_prices(app) -> None:
                         await send_rate_limited(
                             app.bot, chat_id, text, emoji=trend_emojis(raw_change)
                         )
-                    if (
-                        volume is not None
-                        and last_volume is not None
-                        and last_volume > 0
-                    ):
-                        raw_vol_change = (volume - last_volume) / last_volume * 100
-                        if abs(raw_vol_change) >= config.VOLUME_THRESHOLD:
-                            symbol = api.symbol_for(coin)
-                            msg = (
-                                f"{symbol} volume {raw_vol_change:+.2f}% "
-                                f"(24h {volume:,.0f})"
-                            )
-                            await send_rate_limited(
-                                app.bot,
-                                chat_id,
-                                msg,
-                                emoji=trend_emojis(raw_vol_change),
-                            )
+                    if config.ENABLE_VOLUME_ALERTS:
+                        if (
+                            volume is not None
+                            and last_volume is not None
+                            and last_volume > 0
+                        ):
+                            raw_vol_change = (volume - last_volume) / last_volume * 100
+                            if abs(raw_vol_change) >= config.VOLUME_THRESHOLD:
+                                symbol = api.symbol_for(coin)
+                                msg = (
+                                    f"{symbol} volume {raw_vol_change:+.2f}% "
+                                    f"(24h {volume:,.0f})"
+                                )
+                                await send_rate_limited(
+                                    app.bot,
+                                    chat_id,
+                                    msg,
+                                    emoji=trend_emojis(raw_vol_change),
+                                )
                     await db.set_last_price(sub_id, price, volume)
 
 
@@ -458,6 +466,12 @@ def get_settings_keyboard() -> InlineKeyboardMarkup:
             InlineKeyboardButton(
                 f"milestones: {'on' if config.ENABLE_MILESTONE_ALERTS else 'off'}",
                 callback_data="settings:milestones",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                f"volume: {'on' if config.ENABLE_VOLUME_ALERTS else 'off'}",
+                callback_data="settings:volume",
             )
         ],
         [
@@ -935,7 +949,8 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if len(context.args) < 2:
         usage = (
             f"{ERROR_EMOJI} Usage: "
-            "/settings <threshold|interval|milestones|currency> <value>"
+            "/settings <threshold|interval|milestones|volume|liquidations|"
+            "currency> <value>"
         )
         await update.message.reply_text(usage)
         return
@@ -972,6 +987,14 @@ async def settings_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         config.ENABLE_MILESTONE_ALERTS = val == "on"
         state = "enabled" if config.ENABLE_MILESTONE_ALERTS else "disabled"
         await update.message.reply_text(f"{SUCCESS_EMOJI} Milestone alerts {state}")
+    elif key == "volume":
+        val = value.lower()
+        if val not in {"on", "off"}:
+            await update.message.reply_text(f"{ERROR_EMOJI} Volume must be on or off")
+            return
+        config.ENABLE_VOLUME_ALERTS = val == "on"
+        state = "enabled" if config.ENABLE_VOLUME_ALERTS else "disabled"
+        await update.message.reply_text(f"{SUCCESS_EMOJI} Volume alerts {state}")
     elif key == "liquidations":
         val = value.lower()
         if val not in {"on", "off"}:
@@ -1076,6 +1099,10 @@ async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             config.ENABLE_MILESTONE_ALERTS = not config.ENABLE_MILESTONE_ALERTS
             state = "enabled" if config.ENABLE_MILESTONE_ALERTS else "disabled"
             text = f"{SUCCESS_EMOJI} Milestone alerts {state}"
+        elif key == "volume":
+            config.ENABLE_VOLUME_ALERTS = not config.ENABLE_VOLUME_ALERTS
+            state = "enabled" if config.ENABLE_VOLUME_ALERTS else "disabled"
+            text = f"{SUCCESS_EMOJI} Volume alerts {state}"
         elif key == "liquidations":
             config.ENABLE_LIQUIDATION_ALERTS = not config.ENABLE_LIQUIDATION_ALERTS
             state = "enabled" if config.ENABLE_LIQUIDATION_ALERTS else "disabled"

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -94,6 +94,16 @@ async def test_settings_update_liquidations():
 
 
 @pytest.mark.asyncio
+async def test_settings_update_volume():
+    update = DummyUpdate()
+    ctx = DummyContext(["volume", "off"])
+    prev = config.ENABLE_VOLUME_ALERTS
+    await handlers.settings_cmd(update, ctx)
+    assert config.ENABLE_VOLUME_ALERTS is False
+    config.ENABLE_VOLUME_ALERTS = prev
+
+
+@pytest.mark.asyncio
 async def test_settings_pricecheck_readonly():
     update = DummyUpdate()
     ctx = DummyContext(["pricecheck", "30s"])
@@ -133,3 +143,17 @@ async def test_settings_button_toggle_milestones():
     assert isinstance(query.reply_markup, InlineKeyboardMarkup)
     assert bot.sent
     config.ENABLE_MILESTONE_ALERTS = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_button_toggle_volume():
+    bot = DummyBot()
+    query = DummyCallbackQuery("settings:volume")
+    update = DummyCallbackUpdate(query)
+    ctx = DummyContext([], bot)
+    prev = config.ENABLE_VOLUME_ALERTS
+    await handlers.button(update, ctx)
+    assert config.ENABLE_VOLUME_ALERTS != prev
+    assert isinstance(query.reply_markup, InlineKeyboardMarkup)
+    assert bot.sent
+    config.ENABLE_VOLUME_ALERTS = prev

--- a/tests/test_volume_alerts.py
+++ b/tests/test_volume_alerts.py
@@ -85,3 +85,38 @@ async def test_volume_drop_alert(tmp_path, monkeypatch):
     await handlers.check_prices(app)
     MILESTONE_CACHE.clear()
     assert any("volume" in msg for _, msg in bot.sent)
+
+
+@pytest.mark.asyncio
+async def test_volume_alerts_disabled(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    config.VOLUME_THRESHOLD = 10.0
+    await db.subscribe_coin(1, "bitcoin", 0.1, 300)
+    async with aiosqlite.connect(config.DB_FILE) as conn:
+        await conn.execute(
+            (
+                "UPDATE subscriptions SET last_price=?, last_volume=?, "
+                "last_alert_ts=? WHERE id=1"
+            ),
+            (100.0, 1000.0, time.time() - 600),
+        )
+        await conn.commit()
+
+    async def fake_markets(coins, session=None, user=None):
+        return {c: {"current_price": 101.0} for c in coins}
+
+    async def fake_volume(coin, session=None, user=None):
+        return 2000.0
+
+    monkeypatch.setattr(api, "get_markets", fake_markets)
+    monkeypatch.setattr(api, "get_volume", fake_volume)
+    bot = DummyBot()
+    app = DummyApp(bot)
+    MILESTONE_CACHE.clear()
+    prev = config.ENABLE_VOLUME_ALERTS
+    config.ENABLE_VOLUME_ALERTS = False
+    await handlers.check_prices(app)
+    MILESTONE_CACHE.clear()
+    config.ENABLE_VOLUME_ALERTS = prev
+    assert not any("volume" in msg for _, msg in bot.sent)


### PR DESCRIPTION
## Summary
- allow disabling volume alerts via `ENABLE_VOLUME_ALERTS`
- document the new setting in README and `.env.example`
- include volume toggle in the settings UI
- add tests for new setting and ensure volume alerts respect it

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797df6f5d48321b98f31e8fefcbd27