### PR TITLE
Improve /status command with timeline

### DIFF
--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -1,6 +1,7 @@
 """Asynchronous SQLite helpers for caching coin data and subscriptions."""
 
 import json
+import os
 import time
 from typing import List, Optional, Tuple
 
@@ -456,3 +457,13 @@ async def set_user_settings(chat_id: int, **kwargs) -> None:
                 (chat_id, *kwargs.values()),
             )
         await db.commit()
+
+
+async def get_db_stats() -> Tuple[int, int]:
+    """Return subscription count and file size in bytes."""
+    async with aiosqlite.connect(config.DB_FILE) as db:
+        cursor = await db.execute("SELECT COUNT(*) FROM subscriptions")
+        count_row = await cursor.fetchone()
+        await cursor.close()
+    size = os.path.getsize(config.DB_FILE) if os.path.exists(config.DB_FILE) else 0
+    return (count_row[0], size)

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -51,6 +51,8 @@ async def test_status_cmd_basic():
     await handlers.status_cmd(update, ctx)
     assert bot.photos
     assert update.message.texts
+    text = update.message.texts[0]
+    assert "API:" in text and "DB:" in text
     counts = api.status_counts()
     assert 200 not in counts
     assert counts[429] == 1


### PR DESCRIPTION
## Summary
- add `get_db_stats` helper for subscription count
- plot API status history as a timeline
- display bot, API and DB info in `/status`
- update tests for new output

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a03cf9cd08321ac067531fd214338