### PR TITLE
Add documentation for absolute price alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 
 ### Commands
 
-- `/add <coin> [pct] [interval]` – subscribe to price alerts
+ - `/add <coin> [pct|>price|<price] [interval]` – subscribe to price alerts
+   (use `>price` or `<price` to trigger when the value is crossed)
 - `/remove <coin>` – remove a subscription
 - `/clear` – remove all subscriptions
 - `/list` – list active subscriptions

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -558,7 +558,11 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def subscribe_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Subscribe the chat to price alerts for a coin."""
+    """Subscribe the chat to price alerts for a coin.
+
+    The second argument can be a percent change or an absolute price
+    prefixed with ``>`` or ``<`` to alert when that value is crossed.
+    """
     if not context.args:
         await update.message.reply_text(
             f"{ERROR_EMOJI} Usage: /add <coin> [pct] [interval]"


### PR DESCRIPTION
## Summary
- document absolute price alert syntax in README
- clarify subscribe command docstring about target prices

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0a8a43288321a9e6a41a4527beea