### PR TITLE
Hide USDT from top and trending

### DIFF
--- a/pricepulsebot/api.py
+++ b/pricepulsebot/api.py
@@ -55,6 +55,13 @@ def encoded(coin: str) -> str:
     return quote(coin, safe="-")
 
 
+def _is_usdt(item: dict) -> bool:
+    """Return ``True`` if *item* represents USDT/Tether."""
+    coin_id = str(item.get("id", "")).lower()
+    symbol = str(item.get("symbol", "")).lower()
+    return coin_id == "tether" or symbol == "usdt"
+
+
 async def resolve_pair(
     value: str, quote: str = "USDT", *, user: Optional[int] = None
 ) -> str:
@@ -711,6 +718,7 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
             if coin_id and symbol:
                 config.COIN_SYMBOLS[coin_id] = symbol.upper()
                 config.SYMBOL_TO_COIN[symbol.lower()] = coin_id
+        cached = [c for c in cached if not _is_usdt(c)]
         config.COINS = [c.get("id") for c in cached if c.get("id")]
         cached.sort(key=lambda x: (x["change_24h"] is None, -(x["change_24h"] or 0)))
         return cached
@@ -730,6 +738,8 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
                 symbol = item.get("symbol")
                 name = item.get("name")
                 if not coin_id:
+                    continue
+                if coin_id == "tether" or (symbol and symbol.lower() == "usdt"):
                     continue
                 ids.append(coin_id)
                 infos.append((coin_id, symbol, name))
@@ -783,6 +793,7 @@ async def fetch_trending_coins() -> Optional[list[dict]]:
             if coin_id and symbol:
                 config.COIN_SYMBOLS[coin_id] = symbol.upper()
                 config.SYMBOL_TO_COIN[symbol.lower()] = coin_id
+        cached = [c for c in cached if not _is_usdt(c)]
         config.COINS = [c.get("id") for c in cached if c.get("id")]
         cached.sort(key=lambda x: (x["change_24h"] is None, -(x["change_24h"] or 0)))
         return cached
@@ -811,6 +822,8 @@ async def fetch_top_coins(per_page: int = 100) -> Optional[list[dict]]:
                 coin_id = item.get("id")
                 symbol = item.get("symbol")
                 if not coin_id:
+                    continue
+                if coin_id == "tether" or (symbol and symbol.lower() == "usdt"):
                     continue
                 coins.append(coin_id)
                 if symbol:

--- a/tests/test_top_coins.py
+++ b/tests/test_top_coins.py
@@ -25,3 +25,26 @@ async def test_fetch_top_coins_updates_config(monkeypatch):
     assert result and result[0]["id"] == "bitcoin"
     assert config.TOP_COINS[0] == "bitcoin"
     assert config.COIN_SYMBOLS["bitcoin"] == "BTC"
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_coins_excludes_usdt(monkeypatch):
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/coins/markets",
+            "GET",
+            Response(
+                text=(
+                    '[{"id": "tether", "symbol": "usdt", "current_price": 1.0, '
+                    '"price_change_percentage_24h": 0.0},'
+                    '{"id": "bitcoin", "symbol": "btc", "current_price": 2.0, '
+                    '"price_change_percentage_24h": 1.0}]'
+                ),
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        result = await api.fetch_top_coins(per_page=100)
+    assert all(item["id"] != "tether" for item in result)
+    assert "tether" not in config.TOP_COINS

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -69,3 +69,43 @@ async def test_fetch_trending_coins_uses_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(api, "api_get", fail)
     result = await api.fetch_trending_coins()
     assert result == cached
+
+
+@pytest.mark.asyncio
+async def test_fetch_trending_coins_excludes_usdt(tmp_path):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    async with ResponsesMockServer() as ars:
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/search/trending",
+            "GET",
+            Response(
+                text=(
+                    '{"coins": ['
+                    '{"item": {"id": "tether", "symbol": "usdt", "name": "Tether"}},'
+                    '{"item": {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin"}}'
+                    "]}"
+                ),
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        ars.add(
+            "api.coingecko.com",
+            "/api/v3/coins/markets",
+            "GET",
+            Response(
+                text=(
+                    '[{"id": "tether", "current_price": 1.0, '
+                    '"price_change_percentage_24h": 0.0},'
+                    '{"id": "bitcoin", "current_price": 2.0, '
+                    '"price_change_percentage_24h": 1.0}]'
+                ),
+                status=200,
+                headers={"Content-Type": "application/json"},
+            ),
+        )
+        result = await api.fetch_trending_coins()
+    assert all(item["id"] != "tether" for item in result)
+    assert "tether" not in config.COINS


### PR DESCRIPTION
## Summary
- add `_is_usdt` helper to identify Tether
- skip Tether in `fetch_trending_coins`
- skip Tether in `fetch_top_coins`
- ensure tests cover exclusion logic

## Testing
- `flake8 pricepulsebot tests run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0cf301ac8321b378e976111d7dca