### PR TITLE
Batch coin refresh

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -455,8 +455,7 @@ async def refresh_cache(app) -> None:
         coins = [row[0] for row in await cursor.fetchall()]
         await cursor.close()
     async with aiohttp.ClientSession() as session:
-        for coin in coins:
-            await api.refresh_coin_data(coin, session=session)
+        await api.refresh_coins_data(coins, session=session)
     await api.get_global_overview(user=None)
 
 


### PR DESCRIPTION
## Summary
- add `refresh_coins_data` to batch market requests
- call the new batch helper from `refresh_cache`

## Testing
- `isort pricepulsebot tests`
- `black pricepulsebot tests`
- `flake8 pricepulsebot tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a364dd4448321b25a7c966c9f0170