### PR TITLE
Implement inline news links

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -954,6 +954,7 @@ async def news_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             return
 
     async with aiohttp.ClientSession() as session:
+        seen: set[str] = set()
         for coin in coins:
             items = await api.get_news(
                 coin, session=session, user=update.effective_chat.id
@@ -963,9 +964,21 @@ async def news_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     f"{ERROR_EMOJI} No news for {api.symbol_for(coin)}"
                 )
                 continue
-            lines = [f"- {i.get('title')}" for i in items[:5]]
-            text = f"{INFO_EMOJI} News for {api.symbol_for(coin)}:\n" + "\n".join(lines)
-            await update.message.reply_text(text)
+            for item in items[:5]:
+                url = item.get("url")
+                title = item.get("title")
+                if not title:
+                    continue
+                if not context.args and url in seen:
+                    continue
+                if url:
+                    seen.add(url)
+                    text = f'{INFO_EMOJI} <a href="{url}">{title}</a>'
+                else:
+                    text = f"{INFO_EMOJI} {title}"
+                await update.message.reply_text(
+                    text, parse_mode="HTML", disable_web_page_preview=True
+                )
 
 
 async def valuearea_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -58,3 +58,23 @@ async def test_news_cmd_subscriptions(tmp_path, monkeypatch):
     ctx = DummyContext([])
     await handlers.news_cmd(update, ctx)
     assert update.message.texts
+
+
+@pytest.mark.asyncio
+async def test_news_cmd_dedup_and_links(tmp_path, monkeypatch):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+    await db.subscribe_coin(1, "ethereum", 1.0, 60)
+
+    async def fake_news(coin, session=None, user=None):
+        return [{"title": "Hello", "url": "https://example.com"}]
+
+    monkeypatch.setattr(api, "get_news", fake_news)
+
+    update = DummyUpdate()
+    ctx = DummyContext([])
+    await handlers.news_cmd(update, ctx)
+    assert len(update.message.texts) == 1
+    assert "https://example.com" in update.message.texts[0]
+    assert "Hello" in update.message.texts[0]


### PR DESCRIPTION
## Summary
- expand `/news` command to use inline article links and avoid duplicates
- test new news behaviour

## Testing
- `isort .`
- `black .`
- `flake8 pricepulsebot tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab2e2ddec83219e16343eb5cbde05