### PR TITLE
Implement /charts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Create a `.env` file from the example. It holds credentials and runtime options:
 - `/clear` – remove all subscriptions
 - `/list` – list active subscriptions
 - `/info <coin>` – show current coin data
- - `/chart <coin> [period]` – plot price history for a timeframe (alias `/charts`)
+- `/chart <coin> [period]` – plot price history for a timeframe
+- `/charts [period]` – plot price history for all subscriptions
 - `/news [coin]` – show latest news (uses subscriptions when omitted)
 - `/trends` – show trending coins
 - `/top` – show top market cap coins

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -37,6 +37,7 @@ async def main() -> None:
     app.add_handler(CommandHandler("list", handlers.list_cmd))
     app.add_handler(CommandHandler("info", handlers.info_cmd))
     app.add_handler(CommandHandler("chart", handlers.chart_cmd))
+    app.add_handler(CommandHandler("charts", handlers.charts_cmd))
     app.add_handler(CommandHandler("news", handlers.news_cmd))
     app.add_handler(CommandHandler("trends", handlers.trends_cmd))
     app.add_handler(CommandHandler("top", handlers.top_cmd))


### PR DESCRIPTION
## Summary
- update README with new `/charts` description
- add `/charts` handler for all subscribed coin charts
- list `charts` in bot command categories and register handler

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7fe1f4d88321ad8e2add02e517f1