### PR TITLE
Use emoji on chart reload button

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -65,6 +65,7 @@ SUCCESS_EMOJI = "\u2705"
 ERROR_EMOJI = "\u26a0\ufe0f"
 SETTINGS_EMOJI = "\u2699\ufe0f"
 BACK_EMOJI = "\u2b05\ufe0f"
+RELOAD_EMOJI = "\U0001f504"
 
 # Commands organized by category for help output
 COMMAND_CATEGORIES: dict[str, list[tuple[str, str]]] = {
@@ -851,7 +852,7 @@ async def _send_chart(
         [
             [
                 InlineKeyboardButton(
-                    "Reload",
+                    RELOAD_EMOJI,
                     callback_data=f"chart:{coin}:{seconds}:reload",
                 ),
                 InlineKeyboardButton("1h", callback_data=f"chart:{coin}:3600"),


### PR DESCRIPTION
## Summary
- add `RELOAD_EMOJI` constant
- show the emoji instead of the text "Reload" in the chart inline keyboard

## Testing
- `isort pricepulsebot/handlers.py`
- `black pricepulsebot/handlers.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab26e841483218dcdf82dac5078d4