### PR TITLE
Add setting for chart reload behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ DEFAULT_INTERVAL=5m
 PRICE_CHECK_INTERVAL=30s
 # How long cached chart data remains valid
 CHART_CACHE_TTL=1h
+# Delete chart image on reload (true/false)
+DELETE_CHART_ON_RELOAD=true
 # Enable price milestone alerts (true/false)
 ENABLE_MILESTONE_ALERTS=true
 # Enable volume alerts (true/false)

--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -56,6 +56,7 @@ VOLUME_THRESHOLD = float(os.getenv("VOLUME_THRESHOLD", str(DEFAULT_THRESHOLD)))
 DEFAULT_INTERVAL = parse_duration(os.getenv("DEFAULT_INTERVAL", "5m"))
 PRICE_CHECK_INTERVAL = parse_duration(os.getenv("PRICE_CHECK_INTERVAL", "60s"))
 CHART_CACHE_TTL = parse_duration(os.getenv("CHART_CACHE_TTL", "1h"))
+DELETE_CHART_ON_RELOAD = os.getenv("DELETE_CHART_ON_RELOAD", "true").lower() == "true"
 ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() == "true"
 ENABLE_VOLUME_ALERTS = os.getenv("ENABLE_VOLUME_ALERTS", "true").lower() == "true"
 VS_CURRENCY = os.getenv("DEFAULT_VS_CURRENCY", "usd").lower()

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -94,6 +94,16 @@ async def test_settings_update_volume():
 
 
 @pytest.mark.asyncio
+async def test_settings_update_deletechart():
+    update = DummyUpdate()
+    ctx = DummyContext(["deletechart", "off"])
+    prev = config.DELETE_CHART_ON_RELOAD
+    await handlers.settings_cmd(update, ctx)
+    assert config.DELETE_CHART_ON_RELOAD is False
+    config.DELETE_CHART_ON_RELOAD = prev
+
+
+@pytest.mark.asyncio
 async def test_settings_pricecheck_readonly():
     update = DummyUpdate()
     ctx = DummyContext(["pricecheck", "30s"])
@@ -149,3 +159,17 @@ async def test_settings_button_toggle_volume():
     assert isinstance(query.reply_markup, InlineKeyboardMarkup)
     assert bot.sent
     config.ENABLE_VOLUME_ALERTS = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_button_toggle_deletechart():
+    bot = DummyBot()
+    query = DummyCallbackQuery("settings:deletechart")
+    update = DummyCallbackUpdate(query)
+    ctx = DummyContext([], bot)
+    prev = config.DELETE_CHART_ON_RELOAD
+    await handlers.button(update, ctx)
+    assert config.DELETE_CHART_ON_RELOAD != prev
+    assert isinstance(query.reply_markup, InlineKeyboardMarkup)
+    assert bot.sent
+    config.DELETE_CHART_ON_RELOAD = prev

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -75,3 +75,24 @@ async def test_settings_menu_volume_toggle():
     assert config.ENABLE_VOLUME_ALERTS != prev
     assert isinstance(update.message.markups[-1], ReplyKeyboardMarkup)
     config.ENABLE_VOLUME_ALERTS = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_menu_deletechart_toggle():
+    prev = config.DELETE_CHART_ON_RELOAD
+    update = DummyUpdate(SETTINGS_EMOJI)
+    ctx = DummyContext()
+    await handlers.menu(update, ctx)
+    assert any(
+        "delete chart" in btn.text
+        for row in update.message.markups[-1].keyboard
+        for btn in row
+    )
+
+    update.message.text = (
+        f"delete chart: {'on' if not config.DELETE_CHART_ON_RELOAD else 'off'}"
+    )
+    await handlers.menu(update, ctx)
+    assert config.DELETE_CHART_ON_RELOAD != prev
+    assert isinstance(update.message.markups[-1], ReplyKeyboardMarkup)
+    config.DELETE_CHART_ON_RELOAD = prev


### PR DESCRIPTION
## Summary
- add `DELETE_CHART_ON_RELOAD` config option
- extend DB schema and user settings with a `delete_chart` flag
- allow toggling chart deletion in settings menus and commands
- respect user preference when reloading charts
- document new env variable
- test settings updates and menu behaviour

## Testing
- `isort . && black .`
- `python3 -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b30b9e030832185cc66f1d0e42831