### PR TITLE
Enable editing subscription parameters from /list

### DIFF
--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -66,6 +66,7 @@ ERROR_EMOJI = "\u26a0\ufe0f"
 SETTINGS_EMOJI = "\u2699\ufe0f"
 BACK_EMOJI = "\u2b05\ufe0f"
 RELOAD_EMOJI = "\U0001f504"
+EDIT_EMOJI = "\u270f\ufe0f"
 
 # Commands organized by category for help output
 COMMAND_CATEGORIES: dict[str, list[tuple[str, str]]] = {
@@ -750,7 +751,12 @@ async def list_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     for coin, text in entries:
         keyboard = InlineKeyboardMarkup(
-            [[InlineKeyboardButton("Remove", callback_data=f"del:{coin}")]]
+            [
+                [
+                    InlineKeyboardButton("Remove", callback_data=f"del:{coin}"),
+                    InlineKeyboardButton("Edit", callback_data=f"edit:{coin}"),
+                ]
+            ]
         )
         await update.message.reply_text(text, reply_markup=keyboard)
 
@@ -1250,11 +1256,110 @@ async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         )
     elif query.data.startswith("edit:"):
         coin = query.data.split(":", 1)[1]
-        await context.bot.send_message(
-            chat_id=query.message.chat_id,
-            text=f"{INFO_EMOJI} Use /add {coin} [pct] [interval] to update",
+        subs = await db.list_subscriptions(query.message.chat_id)
+        for _, c, th, interval, *_ in subs:
+            if c == coin:
+                threshold = th
+                iv = interval
+                break
+        else:
+            await query.answer()
+            return
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        f"threshold: ±{threshold}%", callback_data=f"thr:{coin}"
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        f"interval: {config.format_interval(iv)}",
+                        callback_data=f"int:{coin}",
+                    )
+                ],
+                [InlineKeyboardButton(f"{BACK_EMOJI} Back", callback_data="list")],
+            ]
         )
-        await query.edit_message_reply_markup(reply_markup=None)
+        entries = await build_sub_entries(query.message.chat_id)
+        text = next((t for c, t in entries if c == coin), coin)
+        await query.edit_message_text(text, reply_markup=keyboard)
+    elif query.data.startswith("thr:"):
+        coin = query.data.split(":", 1)[1]
+        subs = await db.list_subscriptions(query.message.chat_id)
+        for _, c, th, interval, *_ in subs:
+            if c == coin:
+                current_th = th
+                iv = interval
+                break
+        else:
+            await query.answer()
+            return
+        options = [0.1, 0.5, 1.0, 2.0, 5.0]
+        try:
+            idx = options.index(current_th)
+        except ValueError:
+            idx = -1
+        new_th = options[(idx + 1) % len(options)]
+        await db.unsubscribe_coin(query.message.chat_id, coin)
+        await db.subscribe_coin(query.message.chat_id, coin, new_th, iv)
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        f"threshold: ±{new_th}%", callback_data=f"thr:{coin}"
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        f"interval: {config.format_interval(iv)}",
+                        callback_data=f"int:{coin}",
+                    )
+                ],
+                [InlineKeyboardButton(f"{BACK_EMOJI} Back", callback_data="list")],
+            ]
+        )
+        entries = await build_sub_entries(query.message.chat_id)
+        text = next((t for c, t in entries if c == coin), coin)
+        await query.edit_message_text(text, reply_markup=keyboard)
+    elif query.data.startswith("int:"):
+        coin = query.data.split(":", 1)[1]
+        subs = await db.list_subscriptions(query.message.chat_id)
+        for _, c, th, interval, *_ in subs:
+            if c == coin:
+                threshold = th
+                current_int = interval
+                break
+        else:
+            await query.answer()
+            return
+        options = [60, 300, 600, 1800, 3600]
+        try:
+            idx = options.index(current_int)
+        except ValueError:
+            idx = -1
+        new_int = options[(idx + 1) % len(options)]
+        await db.unsubscribe_coin(query.message.chat_id, coin)
+        await db.subscribe_coin(query.message.chat_id, coin, threshold, new_int)
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        f"threshold: ±{threshold}%", callback_data=f"thr:{coin}"
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        f"interval: {config.format_interval(new_int)}",
+                        callback_data=f"int:{coin}",
+                    )
+                ],
+                [InlineKeyboardButton(f"{BACK_EMOJI} Back", callback_data="list")],
+            ]
+        )
+        entries = await build_sub_entries(query.message.chat_id)
+        text = next((t for c, t in entries if c == coin), coin)
+        await query.edit_message_text(text, reply_markup=keyboard)
     elif query.data.startswith("chart:"):
         parts = query.data.split(":")
         coin = parts[1]

--- a/tests/test_list_edit.py
+++ b/tests/test_list_edit.py
@@ -1,0 +1,115 @@
+import pytest
+
+import pricepulsebot.config as config
+import pricepulsebot.db as db
+import pricepulsebot.handlers as handlers
+from pricepulsebot.handlers import InlineKeyboardMarkup
+
+
+class DummyBot:
+    async def send_chat_action(self, chat_id, action):
+        pass
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+        self.markups = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = type("Chat", (), {"id": 1})()
+
+
+class DummyContext:
+    def __init__(self, bot):
+        self.bot = bot
+        self.args = []
+
+
+class DummyCallbackQuery:
+    def __init__(self, data):
+        self.data = data
+        self.message = type("Msg", (), {"chat_id": 1})()
+        self.reply_markup = None
+
+    async def answer(self):
+        pass
+
+    async def edit_message_text(self, text, **kwargs):
+        self.reply_markup = kwargs.get("reply_markup")
+
+    async def edit_message_reply_markup(self, reply_markup=None):
+        self.reply_markup = reply_markup
+
+
+class DummyCallbackUpdate:
+    def __init__(self, query):
+        self.callback_query = query
+
+
+@pytest.mark.asyncio
+async def test_list_cmd_has_edit_button(tmp_path):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+    await db.set_coin_data(
+        "bitcoin",
+        {
+            "price": 10.0,
+            "market_info": {
+                "current_price": 10.0,
+                "market_cap": 1000,
+                "price_change_percentage_24h": 1.0,
+            },
+            "info": {"symbol": "btc", "name": "Bitcoin"},
+            "chart_7d": [],
+        },
+    )
+    bot = DummyBot()
+    update = DummyUpdate()
+    ctx = DummyContext(bot)
+    await handlers.list_cmd(update, ctx)
+    assert update.message.markups
+    kb = update.message.markups[0]
+    assert isinstance(kb, InlineKeyboardMarkup)
+    assert any(b.callback_data.startswith("edit:") for b in kb.inline_keyboard[0])
+
+
+@pytest.mark.asyncio
+async def test_edit_threshold_button(tmp_path):
+    config.DB_FILE = str(tmp_path / "subs.db")
+    await db.init_db()
+    await db.subscribe_coin(1, "bitcoin", 1.0, 60)
+    await db.set_coin_data(
+        "bitcoin",
+        {
+            "price": 10.0,
+            "market_info": {
+                "current_price": 10.0,
+                "market_cap": 1000,
+                "price_change_percentage_24h": 1.0,
+            },
+            "info": {"symbol": "btc", "name": "Bitcoin"},
+            "chart_7d": [],
+        },
+    )
+    query = DummyCallbackQuery("edit:bitcoin")
+    update = DummyCallbackUpdate(query)
+    ctx = DummyContext(DummyBot())
+    await handlers.button(update, ctx)
+    assert query.reply_markup
+    kb = query.reply_markup
+    assert any(btn.callback_data.startswith("thr:") for btn in kb.inline_keyboard[0])
+
+    query2 = DummyCallbackQuery("thr:bitcoin")
+    update2 = DummyCallbackUpdate(query2)
+    await handlers.button(update2, ctx)
+    subs = await db.list_subscriptions(1)
+    assert subs[0][2] != 1.0


### PR DESCRIPTION
## Summary
- add edit emoji constant
- show Edit buttons in /list command
- add inline callbacks to modify threshold and interval
- add tests for edit button functionality

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b32be227c8321abf926928e1e1184