### PR TITLE
Implement persistent database connection

### DIFF
--- a/pricepulsebot/db.py
+++ b/pricepulsebot/db.py
@@ -9,6 +9,29 @@ import aiosqlite
 
 from . import config
 
+_connection: Optional[aiosqlite.Connection] = None
+_current_db_file: Optional[str] = None
+
+
+async def get_connection() -> aiosqlite.Connection:
+    """Return a global aiosqlite connection, creating it if needed."""
+    global _connection, _current_db_file
+    if _connection is None or _current_db_file != config.DB_FILE:
+        if _connection is not None:
+            await _connection.close()
+        _connection = await aiosqlite.connect(config.DB_FILE)
+        _current_db_file = config.DB_FILE
+    return _connection
+
+
+async def close_connection() -> None:
+    """Close the global aiosqlite connection if it exists."""
+    global _connection, _current_db_file
+    if _connection is not None:
+        await _connection.close()
+        _connection = None
+        _current_db_file = None
+
 
 async def init_db() -> None:
     """Create database tables if they do not already exist."""

--- a/pricepulsebot/handlers.py
+++ b/pricepulsebot/handlers.py
@@ -289,16 +289,16 @@ async def send_rate_limited(
 async def check_prices(app) -> None:
     """Check all subscriptions and send price alerts when needed."""
     async with aiohttp.ClientSession() as http_session:
-        async with db.aiosqlite.connect(config.DB_FILE) as database:
-            cursor = await database.execute(
-                (
-                    "SELECT id, chat_id, coin_id, threshold, interval, target_price, "
-                    "direction, last_price, last_volume, last_alert_ts "
-                    "FROM subscriptions"
-                )
+        database = await db.get_connection()
+        cursor = await database.execute(
+            (
+                "SELECT id, chat_id, coin_id, threshold, interval, target_price, "
+                "direction, last_price, last_volume, last_alert_ts "
+                "FROM subscriptions"
             )
-            rows = await cursor.fetchall()
-            await cursor.close()
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
         by_coin: Dict[
             str,
             List[
@@ -504,10 +504,10 @@ async def check_prices(app) -> None:
 
 async def refresh_cache(app) -> None:
     """Refresh cached data for coins referenced in the database."""
-    async with db.aiosqlite.connect(config.DB_FILE) as database:
-        cursor = await database.execute("SELECT DISTINCT coin_id FROM subscriptions")
-        coins = [row[0] for row in await cursor.fetchall()]
-        await cursor.close()
+    database = await db.get_connection()
+    cursor = await database.execute("SELECT DISTINCT coin_id FROM subscriptions")
+    coins = [row[0] for row in await cursor.fetchall()]
+    await cursor.close()
     async with aiohttp.ClientSession() as session:
         await api.refresh_coins_data(coins, session=session)
     await api.get_global_overview(user=None)

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -20,6 +20,7 @@ from . import api, config, db, handlers
 async def main() -> None:
     """Run the Telegram bot until the process receives a stop signal."""
     await db.init_db()
+    await db.get_connection()
     await api.fetch_trending_coins()
     await api.fetch_top_coins()
 
@@ -83,4 +84,5 @@ async def main() -> None:
     await app.stop()
     await app.shutdown()
     scheduler.shutdown()
+    await db.close_connection()
     config.logger.info(f"{config.BOT_NAME} stopped")


### PR DESCRIPTION
## Summary
- manage a global aiosqlite connection in `pricepulsebot.db`
- use the persistent connection in price checks and cache refresh
- open the connection at startup and close it on shutdown

## Testing
- `isort pricepulsebot tests run.py`
- `black pricepulsebot tests run.py`
- `flake8 pricepulsebot tests run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b33dbfc80832182296ca37e4c988f