### PR TITLE
Implement daily market overview feature

### DIFF
--- a/pricepulsebot/config.py
+++ b/pricepulsebot/config.py
@@ -60,6 +60,7 @@ DELETE_CHART_ON_RELOAD = os.getenv("DELETE_CHART_ON_RELOAD", "true").lower() == 
 ENABLE_MILESTONE_ALERTS = os.getenv("ENABLE_MILESTONE_ALERTS", "true").lower() == "true"
 ENABLE_VOLUME_ALERTS = os.getenv("ENABLE_VOLUME_ALERTS", "true").lower() == "true"
 VS_CURRENCY = os.getenv("DEFAULT_VS_CURRENCY", "usd").lower()
+DEFAULT_OVERVIEW = os.getenv("DEFAULT_OVERVIEW", "off").lower()
 
 COINGECKO_API_KEY = os.getenv("COINGECKO_API_KEY")
 COINGECKO_BASE_URL = (

--- a/pricepulsebot/main.py
+++ b/pricepulsebot/main.py
@@ -63,6 +63,24 @@ async def main() -> None:
         seconds=config.PRICE_CHECK_INTERVAL,
         args=(app,),
     )
+    scheduler.add_job(
+        handlers.daily_overview,
+        "cron",
+        hour=8,
+        args=(app, "morning"),
+    )
+    scheduler.add_job(
+        handlers.daily_overview,
+        "cron",
+        hour=12,
+        args=(app, "midday"),
+    )
+    scheduler.add_job(
+        handlers.daily_overview,
+        "cron",
+        hour=18,
+        args=(app, "evening"),
+    )
     scheduler.add_job(api.fetch_trending_coins, "interval", minutes=10)
     scheduler.add_job(api.fetch_top_coins, "interval", minutes=10)
     scheduler.start()

--- a/tests/test_settings_cmd.py
+++ b/tests/test_settings_cmd.py
@@ -173,3 +173,27 @@ async def test_settings_button_toggle_deletechart():
     assert isinstance(query.reply_markup, InlineKeyboardMarkup)
     assert bot.sent
     config.DELETE_CHART_ON_RELOAD = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_update_overview():
+    update = DummyUpdate()
+    ctx = DummyContext(["overview", "morning"])
+    prev = config.DEFAULT_OVERVIEW
+    await handlers.settings_cmd(update, ctx)
+    assert config.DEFAULT_OVERVIEW == "morning"
+    config.DEFAULT_OVERVIEW = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_button_toggle_overview():
+    bot = DummyBot()
+    query = DummyCallbackQuery("settings:overview")
+    update = DummyCallbackUpdate(query)
+    ctx = DummyContext([], bot)
+    prev = config.DEFAULT_OVERVIEW
+    await handlers.button(update, ctx)
+    assert config.DEFAULT_OVERVIEW != prev
+    assert isinstance(query.reply_markup, InlineKeyboardMarkup)
+    assert bot.sent
+    config.DEFAULT_OVERVIEW = prev

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -96,3 +96,22 @@ async def test_settings_menu_deletechart_toggle():
     assert config.DELETE_CHART_ON_RELOAD != prev
     assert isinstance(update.message.markups[-1], ReplyKeyboardMarkup)
     config.DELETE_CHART_ON_RELOAD = prev
+
+
+@pytest.mark.asyncio
+async def test_settings_menu_overview_toggle():
+    prev = config.DEFAULT_OVERVIEW
+    update = DummyUpdate(SETTINGS_EMOJI)
+    ctx = DummyContext()
+    await handlers.menu(update, ctx)
+    assert any(
+        "overview" in btn.text
+        for row in update.message.markups[-1].keyboard
+        for btn in row
+    )
+
+    update.message.text = f"overview: {prev}"
+    await handlers.menu(update, ctx)
+    assert config.DEFAULT_OVERVIEW != prev
+    assert isinstance(update.message.markups[-1], ReplyKeyboardMarkup)
+    config.DEFAULT_OVERVIEW = prev


### PR DESCRIPTION
## Summary
- add `DEFAULT_OVERVIEW` option
- store overview preference in user settings and expose helpers
- extend settings menus to toggle overview schedule
- send periodic market summaries via new `daily_overview` job
- test overview setting handling

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b42e17eb88321b65a36a39544c0eb